### PR TITLE
Fix for Uncaught TypeError: Cannot add property robots, object is not extensible #25

### DIFF
--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -1,4 +1,3 @@
-const _ = require('underscore')
 const clean = require('./clean')
 
 module.exports = MetadataFields
@@ -73,7 +72,7 @@ MetadataFields.prototype.configureType = function (type) {
       'og:article:tag': ''
     }
   }
-  if (fieldsByType[type]) _.extend(this.fields, fieldsByType[type])
+  if (fieldsByType[type]) this.fields = Object.assign({}, this.fields, fieldsByType[type])
   return this
 }
 
@@ -91,7 +90,7 @@ MetadataFields.prototype.lockKeys = function () {
  * @param obj must be in the form of {key: value}
  */
 MetadataFields.prototype.set = function (obj) {
-  if (obj) _.extend(this.fields, obj)
+  if (obj) this.fields = Object.assign({}, this.fields, obj)
   return this
 }
 


### PR DESCRIPTION
In browsers class member objects are not extensible. To fix we simply make a new object here.