### PR TITLE
add customHeaders option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ This package's default options are the values below that you may want to overrid
 
   // custom function to encode the metadata fields before they are returned;
   // defaults to undefined:
-  encode: undefined
+  encode: undefined,
+
+  // custom headers
+  customHeaders: {}
 }
 ```
 
@@ -94,6 +97,17 @@ You can supply a custom function to encode the metadata fields before they are r
 const options = {
   encode: function (value) {
     return encodeURIComponent(value).replace(/['*]/g, escape)
+  }
+}
+```
+
+#### Option: Custom Headers
+You can specify any custom headers such as `cookie`, `accept-language`, `accept-encoding`, `cache-control` etc:
+```javascript
+const options = {
+  customHeaders: {
+    'cookie': 'over18=1;',
+    'accept-language': 'zh-TW,zh;q=0.9,en-NL;q=0.8,en;q=0.7,en-US;q=0.6'
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -16,18 +16,24 @@ module.exports = function (url, options) {
       ensureSecureImageRequest: true,
       sourceMap: {},
       decode: undefined,
-      encode: undefined
+      encode: undefined,
+      customHeaders: {}
     },
     // options passed in override defaults
     options
   )
 
+  const headers = {
+    'User-Agent': opts.userAgent,
+    'From': opts.fromEmail
+  };
+  Object.keys(opts.customHeaders).forEach(function (key) {
+    headers[key] = opts.customHeaders[key];
+  });
+
   const requestOpts = {
     url: url,
-    headers: {
-      'User-Agent': opts.userAgent,
-      'From': opts.fromEmail
-    },
+    headers: headers,
     maxRedirects: opts.maxRedirects,
     encoding: opts.decode ? null : 'utf8',
     timeout: opts.timeout

--- a/index.js
+++ b/index.js
@@ -46,6 +46,9 @@ module.exports = function (url, options) {
       return dfd.reject({ Error: 'response code ' + response.statusCode })
     }
     if (response.statusCode && response.statusCode === 200) {
+      if (!(response.headers && response.headers['content-type'] && response.headers['content-type'].match(/^text\//))) {
+        return dfd.reject({ Error: 'not a text file', Type: (response.headers && response.headers['content-type']) })
+      }
       // rewrite url if our request had to follow redirects to resolve the
       // final link destination (for example: links shortened by bit.ly)
       if (response.request.uri.href) url = response.request.uri.href
@@ -53,6 +56,8 @@ module.exports = function (url, options) {
         body = opts.decode(body)
       }
       return dfd.resolve(parse(url, body, opts))
+    } else {
+      return dfd.reject(err);
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Request an http(s) url and scrape its metadata.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I suggest adding a new option `customHeaders` to specify any header if needed. 

In my use case, a website may prompt a window at the first time to confirm my age is over 18. So in this case I can add a custom cookie in the header:

```javascript
urlMetadata('https://www.ptt.cc/bbs/Gossiping/index.html', {
    customHeaders: {
        'cookie': 'over18=1'
    }
}).then( ... );
```