### PR TITLE
3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+3.5.0
+- new option: parseResponseObject
+- bug: 'unsupported content type' errors hang
+
 3.4.9
 - bugs with `ensureSecureImageRequest` opt `true`
   - favicons not obeying opt when scheme is missing ex: '//:'

--- a/README.md
+++ b/README.md
@@ -31,14 +31,13 @@ In your project file:
 ```javascript
 const urlMetadata = require('url-metadata');
 
-const metadata = await urlMetadata(
-  'https://www.npmjs.com/package/url-metadata',
-  {
-    includeResponseBody: true,
-    ensureSecureImageRequest: true
-  }
-);
-console.log('fetched metadata:', metadata)
+const url = 'https://www.npmjs.com/package/url-metadata';
+try {
+  const metadata = await urlMetadata(url, options);
+  console.log(metadata)
+} catch (err) {
+  console.log(err);
+}
 ```
 
 ### Options & Defaults
@@ -74,17 +73,35 @@ const options = {
   ensureSecureImageRequest: true,
 
   // return raw response body as string
-  includeResponseBody: false
+  includeResponseBody: false,
+
+  // alternate use-case: pass in `Response` object here to be parsed
+  // see example below
+  parseResponseObject: null,
 };
 
-const metadata = await urlMetadata(
-  'https://www.npmjs.com/package/url-metadata',
-  options
-);
+// Basic usage
+const url = 'https://www.npmjs.com/package/url-metadata';
+try {
+  const metadata = await urlMetadata(url, options);
+  console.log(metadata)
+} catch (err) {
+  console.log(err);
+}
+
+// Alternate use-case: parse a Response object instead
+try {
+  // fetch the url in your own code
+  const response = await fetch(url)
+  // ... do other stuff with it...
+  // pass the `response` object to be parsed for its metadata
+  const metadata = await urlMetadata(null, { parseResponseObject: response })
+  console.log(metadata)
+}
 ```
 
 ### Returns
-Returns a promise that is resolved with an object if the response is successful. Note that the `url` field returned will be the last hop in the request chain. If you pass in a url from a url shortener you'll get back the final destination as the `url`.
+Returns a promise resolved with an object. Note that the `url` field returned will be the last hop in the request chain. If you pass in a url from a url shortener you'll get back the final destination as the `url`.
 
 The returned `metadata` object consists of key/value pairs that are all strings, with a few exceptions:
 - `favicons` returns an array of objects containing key/value pairs (strings)
@@ -101,11 +118,9 @@ The returned `metadata` object consists of key/value pairs that are all strings,
 
 ### Troubleshooting
 
-**Issue:** `Response status code 0` or `CORS errors`
-The `fetch` request failed at either the network or protocol level. Possible causes:
+**Issue:** `Response status code 0` or `CORS errors`. The `fetch` request failed at either the network or protocol level. Possible causes:
 - CORS errors. Try changing the mode option (ex: `cors`, `no-cors`, `same-origin`, etc) or setting the `Access-Control-Allow-Origin` header on the server response from the url you are requesting if you have access to it.
 - Trying to access an `https` resource that has invalid certificate, or trying to access an `http` resource from a page with an `https` origin.
 - A browser plugin such as an ad-blocker or privacy protector.
 
-**Issue:** `fetch is not defined`
-Error thrown in a Node.js or browser environment that doesn't have js `fetch` method available. Try upgrading your environment (Node.js version `>=18.0.0`), or you can use an earlier version of this package (version 2.5.0).
+**Issue:** `fetch is not defined`. Error thrown in a Node.js or browser environment that doesn't have `fetch` method available. Try upgrading your environment (Node.js version `>=18.0.0`), or you can use an earlier version of this package (version 2.5.0).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # url-metadata
 
-Request a url and scrape the metadata from its HTML using Node.js or the browser.
+Request a url and scrape the metadata from its HTML using Node.js or the browser. Has an alternate mode that lets you pass in your own `Response` object as well (see `Options`).
 
 Includes:
 - meta tags

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,3 @@
-4.0+ Roadmap
-
-[ ] break out parser as separate package to pass raw html into,
-    use as dependency here
-        https://github.com/laurengarcia/url-metadata/issues/71
-[ ] for non-html, return `response` obj instead of throwing
-        https://github.com/laurengarcia/url-metadata/issues/71
-[ ] add drips funding.json
-      https://twitter.com/wevm_dev/status/1752132002952741018
-[ ] add github actions that run test library automatically
-
-
 3.0+ Roadmap
 
 [X] remove package-lock.json
@@ -45,6 +33,10 @@
       const url = 'http://news.bbc.co.uk '
       - [X] favicons not obeying opt when scheme is missing ex: '//:'
       - [X] handle img tags w `data:` URIs
-
-
+[X] new option: parseResponseObject
+        https://github.com/laurengarcia/url-metadata/issues/71
+[X] bug: 'unsupported content type' errors hang
+[ ] add drips funding.json
+      https://twitter.com/wevm_dev/status/1752132002952741018
+[ ] add github actions that run test library automatically
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (url, options) {
       descriptionLength: 750,
       ensureSecureImageRequest: true,
       includeResponseBody: false,
-      parseResponseObject: undefined
+      parseResponseObject: null
     },
     // options passed in override defaults
     options

--- a/index.js
+++ b/index.js
@@ -43,15 +43,19 @@ module.exports = function (url, options) {
         timeout: opts.timeout,
         redirect: 'follow'
       }
-
       return await fetch(url, requestOpts)
+    } else if (!url) {
+      throw new Error('url parameter is missing')
     }
   }
 
   return new Promise((resolve, reject) => {
     fetchData()
       .then((response) => {
-        if (!response || !response.ok) {
+        if (!response) {
+          reject(new Error(`response is ${typeof response}`))
+        }
+        if (!response.ok) {
           reject(new Error(`response code ${response.status}`))
         }
 

--- a/index.js
+++ b/index.js
@@ -17,65 +17,77 @@ module.exports = function (url, options) {
       timeout: 10000,
       descriptionLength: 750,
       ensureSecureImageRequest: true,
-      includeResponseBody: false
+      includeResponseBody: false,
+      parseResponseObject: undefined
     },
     // options passed in override defaults
     options
   )
 
-  const requestOpts = {
-    method: 'GET',
-    headers: opts.requestHeaders,
-    cache: opts.cache,
-    mode: opts.mode,
-    decode: opts.decode,
-    timeout: opts.timeout,
-    redirect: 'follow'
+  if (!url && opts.parseResponseObject) {
+    // ignore opts.decode bc response.text() already has own encoding
+    return new Promise((resolve, reject) => {
+      const exec = async () => {
+        const text = await opts.parseResponseObject.text()
+        resolve(parse('', '', text, opts))
+      }
+      exec().catch(reject)
+    })
+  } else {
+    const requestOpts = {
+      method: 'GET',
+      headers: opts.requestHeaders,
+      cache: opts.cache,
+      mode: opts.mode,
+      decode: opts.decode,
+      timeout: opts.timeout,
+      redirect: 'follow'
+    }
+
+    let requestUrl
+    let destinationUrl
+    let contentType
+
+    return fetch(url, requestOpts)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`response code ${response.status}`)
+        }
+
+        // disambiguate `requestUrl` from final destination url
+        // (ex: links shortened by bit.ly)
+        requestUrl = url
+        if (response.url) destinationUrl = response.url
+
+        contentType = response.headers.get('content-type')
+        const isText = contentType && contentType.startsWith('text')
+        const isHTML = contentType && contentType.includes('html')
+
+        if (!isText || !isHTML) {
+          throw new Error(`unsupported content type: ${contentType}`)
+        }
+
+        return response.arrayBuffer()
+      })
+      .then((responseBuffer) => {
+        let charset
+
+        // handle optional user-specified charset
+        if (opts.decode !== 'auto') {
+          charset = opts.decode
+        } else {
+          // extract charset in opts.decode='auto' mode
+          charset = extractCharset(contentType, responseBuffer)
+        }
+        try {
+          const decoder = new TextDecoder(charset)
+          return decoder.decode(responseBuffer)
+        } catch (e) {
+          throw new Error(`decoding with charset: ${charset}`)
+        }
+      })
+      .then((responseDecoded) => {
+        return parse(requestUrl, destinationUrl, responseDecoded, opts)
+      })
   }
-
-  let requestUrl
-  let destinationUrl
-  let contentType
-
-  return fetch(url, requestOpts)
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`response code ${response.status}`)
-      }
-
-      // disambiguate `requestUrl` from final destination url
-      // (ex: links shortened by bit.ly)
-      requestUrl = url
-      if (response.url) destinationUrl = response.url
-
-      contentType = response.headers.get('content-type')
-      const isText = contentType && contentType.startsWith('text')
-      const isHTML = contentType && contentType.includes('html')
-
-      if (!isText || !isHTML) {
-        throw new Error(`unsupported content type: ${contentType}`)
-      }
-
-      return response.arrayBuffer()
-    })
-    .then((responseBuffer) => {
-      let charset
-
-      // handle optional user-specified charset
-      if (opts.decode !== 'auto') {
-        charset = opts.decode
-      } else {
-        // extract charset in opts.decode='auto' mode
-        charset = extractCharset(contentType, responseBuffer)
-      }
-      try {
-        const decoder = new TextDecoder(charset)
-        return decoder.decode(responseBuffer)
-      } catch (e) {
-        throw new Error(`decoding with charset: ${charset}`)
-      }
-    })
-    .then((responseDecoded) => {
-      return parse(requestUrl, destinationUrl, responseDecoded, opts)
-    })
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,11 +2,10 @@ const urlMetadata = require('./../index')
 
 test('basic example', async () => {
   const url = 'https://www.npmjs.com/package/url-metadata'
-  const title = 'url-metadata - npm'
   try {
     const metadata = await urlMetadata(url)
     expect(metadata.url).toBe(url)
-    expect(metadata.title).toBe(title)
+    expect(metadata.title).toBe('url-metadata - npm')
     expect(metadata.lang).toBe('en')
     expect(metadata.charset).toBe('utf-8')
     expect(metadata['og:url']).toBe(url)

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -1,12 +1,21 @@
 const urlMetadata = require('./../index')
 
-test('fails gracefully with malformed URL', async () => {
+test('fails gracefully with malformed url param', async () => {
   const url = 'XYZ'
   try {
     await urlMetadata(url)
   } catch (err) {
     expect(err).toBeDefined()
     expect(err.message).toContain('Failed to parse')
+  }
+})
+
+test('fails gracefully when url param is missing', async () => {
+  try {
+    await urlMetadata(null)
+  } catch (err) {
+    expect(err).toBeDefined()
+    expect(err.message).toContain('url parameter is missing')
   }
 })
 
@@ -41,12 +50,21 @@ test('fails gracefully decoding with bad charset', async () => {
   }
 })
 
-test('option: `parseResponseObject` is empty', async () => {
+test('fails gracefully when option `parseResponseObject` is empty object', async () => {
   try {
     // pass null `url` param & empty response object
     await urlMetadata(null, { parseResponseObject: {} })
   } catch (err) {
     expect(err).toBeDefined()
     expect(err.message).toContain('response code undefined')
+  }
+})
+
+test('fails gracefully when option: `parseResponseObject` is null AND url is null', async () => {
+  try {
+    await urlMetadata(null, { parseResponseObject: null })
+  } catch (err) {
+    expect(err).toBeDefined()
+    expect(err.message).toContain('url parameter is missing')
   }
 })

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -11,6 +11,7 @@ test('fails gracefully with malformed URL', async () => {
 })
 
 test('fails gracefully on !response.ok', async () => {
+  // should 404
   const url = 'http://www.foo.com/imagesz/resized_and_crop/'
   try {
     await urlMetadata(url)
@@ -20,7 +21,6 @@ test('fails gracefully on !response.ok', async () => {
   }
 })
 
-// BUG: throws error but hangs
 test('fails gracefully when fetching non text/html', async () => {
   const url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/98/International_Pok%C3%A9mon_logo.svg/500px-International_Pok%C3%A9mon_logo.svg.png'
   try {
@@ -38,5 +38,15 @@ test('fails gracefully decoding with bad charset', async () => {
   } catch (err) {
     expect(err).toBeDefined()
     expect(err.message).toContain('decoding with charset')
+  }
+})
+
+test('option: `parseResponseObject` is empty', async () => {
+  try {
+    // pass null `url` param & empty response object
+    await urlMetadata(null, { parseResponseObject: {} })
+  } catch (err) {
+    expect(err).toBeDefined()
+    expect(err.message).toContain('response code undefined')
   }
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,6 +1,6 @@
 const urlMetadata = require('./../index')
 
-test('options: `includeResponseBody`, custom `headers`, truncate description, ensureSecureImageRequest', async () => {
+test('options: `includeResponseBody`, custom `headers`, `descriptionLength`, `ensureSecureImageRequest`', async () => {
   const url = 'https://www.npmjs.com/package/url-metadata'
   try {
     const metadata = await urlMetadata(url, {
@@ -21,7 +21,7 @@ test('options: `includeResponseBody`, custom `headers`, truncate description, en
   }
 })
 
-test('option: ensureSecureImageRequest edge cases', async () => {
+test('option: `ensureSecureImageRequest` edge cases', async () => {
   const url = 'http://news.bbc.co.uk '
   try {
     const metadata = await urlMetadata(url, {
@@ -44,11 +44,15 @@ test('option: ensureSecureImageRequest edge cases', async () => {
   }
 })
 
-test('option: parseResponseObject', async () => {
+test('option: `parseResponseObject`', async () => {
   try {
     const url = 'https://www.npmjs.com/package/url-metadata'
     const response = await fetch(url)
+    // pass null `url` param & response object as option`
     const metadata = await urlMetadata(null, { parseResponseObject: response })
+    expect(metadata.url).toBe(url)
+    expect(metadata.title).toBe('url-metadata - npm')
+    expect(metadata.lang).toBe('en')
     expect(metadata.charset).toBe('utf-8')
   } catch (e) {
     expect(e).toBe(undefined)

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -43,3 +43,14 @@ test('option ensureSecureImageRequest edge cases', async () => {
     expect(err).toBe(undefined)
   }
 })
+
+test('option parseResponseObject', async () => {
+  try {
+    const url = 'https://www.npmjs.com/package/url-metadata'
+    const response = await fetch(url)
+    const metadata = await urlMetadata(null, { parseResponseObject: response })
+    expect(metadata.charset).toBe('utf-8')
+  } catch (e) {
+    expect(e).toBe(undefined)
+  }
+})

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,6 +1,6 @@
 const urlMetadata = require('./../index')
 
-test('options `includeResponseBody`, custom `headers`, truncate description, ensureSecureImageRequest', async () => {
+test('options: `includeResponseBody`, custom `headers`, truncate description, ensureSecureImageRequest', async () => {
   const url = 'https://www.npmjs.com/package/url-metadata'
   try {
     const metadata = await urlMetadata(url, {
@@ -21,7 +21,7 @@ test('options `includeResponseBody`, custom `headers`, truncate description, ens
   }
 })
 
-test('option ensureSecureImageRequest edge cases', async () => {
+test('option: ensureSecureImageRequest edge cases', async () => {
   const url = 'http://news.bbc.co.uk '
   try {
     const metadata = await urlMetadata(url, {
@@ -44,7 +44,7 @@ test('option ensureSecureImageRequest edge cases', async () => {
   }
 })
 
-test('option parseResponseObject', async () => {
+test('option: parseResponseObject', async () => {
   try {
     const url = 'https://www.npmjs.com/package/url-metadata'
     const response = await fetch(url)


### PR DESCRIPTION
3.5.0
- new option: parseResponseObject
- bug: 'unsupported content type' errors hang

Addresses use-cases described in #71 