### PR TITLE
Issue #75 Add missing parseResponseObject property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ declare namespace urlMetadata {
     descriptionLength?: number
     ensureSecureImageRequest?: boolean
     includeResponseBody?: boolean
+    parseResponseObject?: Response
   }
   type Result = Record<string, string | boolean | undefined | any>;
 }


### PR DESCRIPTION
Check one:
- [x] I am reporting a bug.
- [ ] I am requesting a feature.

## Steps to reproduce (if bug):
1. Specify `parseResponseObject` in the options of the `url-metadata` function call
2. Reported as unknown property

## Feature request:

### Please attach screenshots if helpful

BTW skipped Husky initiated tests due to problem reported in issue #77 