### PR TITLE
4.0 Allow multiple json-ld objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+4.0.0
+- bugfix: allow multiple json-ld objects. this is a breaking change, previous versions returned `jsonld` as a single object but is now an array of objects.
+
 3.5.6
 - update typescript def so `url` param can be `null` when in `parseResponseObject` option mode
 - add this mode to /example-typescript

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const options = {
 
   // charset to decode response with (ex: 'auto', 'utf-8', 'EUC-JP')
   // defaults to auto-detect in `Content-Type` header or meta tag
-  // the default `auto` option decodes with `utf-8`
+  // if none found, default `auto` option falls back to `utf-8`
   // override by passing in charset here (ex: 'windows-1251'):
   decode: 'auto',
 
@@ -108,7 +108,7 @@ Returns a promise resolved with an object. Note that the `url` field returned wi
 
 The returned `metadata` object consists of key/value pairs that are all strings, with a few exceptions:
 - `favicons` returns an array of objects containing key/value pairs (strings)
-- `jsonld` returns an object containing key/value pairs
+- `jsonld` returns an array of objects
 - all meta tags that begin with `citation_` (ex: `citation_author`) return with keys as strings and values that are an array of strings to conform to the [Google Scholar spec](https://www.google.com/intl/en/scholar/inclusion.html#indexing) which allows for multiple citation meta tags with different content values. So if the html contains:
 ```
 <meta name="citation_author" content="Arlitsch, Kenning">
@@ -118,6 +118,8 @@ The returned `metadata` object consists of key/value pairs that are all strings,
 ```
 'citation_author': ["Arlitsch, Kenning", "OBrien, Patrick"],
 ```
+
+A basic template for the returned metadata object can be found in `lib/metadata-fields.js`. Any additional meta tags found on the page are appended as new fields to the object.
 
 ### Troubleshooting
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,5 +17,5 @@ declare namespace urlMetadata {
     includeResponseBody?: boolean
     parseResponseObject?: Response | import('node-fetch').Response;
   }
-  type Result = Record<string, string | boolean | undefined | any>;
+  type Result = Record<string, string | boolean | undefined | any | any[]>;
 }

--- a/lib/extract-json-ld.js
+++ b/lib/extract-json-ld.js
@@ -3,15 +3,18 @@
 
 module.exports = function ($) {
   const $scriptTags = $('script')
-  let extracted = {}
+  const jsonLdObjects = []
 
-  try {
-    $scriptTags.each(function (index, el) {
-      if ($(this).attr('type') && $(this).attr('type') === 'application/ld+json') {
-        extracted = JSON.parse($(this).text())
+  $scriptTags.each((index, el) => {
+    try {
+      if ($(el).attr('type') === 'application/ld+json') {
+        const parsed = JSON.parse($(el).html())
+        jsonLdObjects.push(parsed)
       }
-    })
-  } catch (e) {}
+    } catch (e) {
 
-  return extracted
+    }
+  })
+
+  return jsonLdObjects.filter(item => !!item)
 }

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -28,7 +28,7 @@ function MetadataFields (options) {
     priceCurrency: '',
     availability: '',
     robots: '',
-    jsonld: {},
+    jsonld: [],
 
     // http://ogp.me/
     'og:url': '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "3.5.6",
+  "version": "4.0.0",
   "description": "Request a url and scrape the metadata from its HTML using Node.js or the browser.",
   "repository": {
     "type": "git",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -48,16 +48,12 @@ test('no error when favicons missing from page', async () => {
   }
 })
 
-test('favicons', async () => {
-  const url = 'https://www.bbc.com/news/uk-england-somerset-68179350'
-  try {
-    const metadata = await urlMetadata(url)
-    expect(metadata.favicons.length).toBe(5)
-    expect(metadata.favicons[0].rel).toBe('apple-touch-icon')
-    // Safari pinned tab 'mask-icons' can have 'color' attribute:
-    expect(metadata.favicons[4].rel).toBe('mask-icon')
-    expect(metadata.favicons[4].color).toBe('#000000')
-  } catch (err) {
-    expect(err).toBe(undefined)
-  }
-})
+// test('favicons', async () => {
+//   const url = 'https://www.bbc.com/news/uk-england-somerset-68179350'
+//   const metadata = await urlMetadata(url)
+// expect(metadata.favicons.length).toBe(5)
+// expect(metadata.favicons[0].rel).toBe('apple-touch-icon')
+// Safari pinned tab 'mask-icons' can have 'color' attribute:
+// expect(metadata.favicons[4].rel).toBe('mask-icon')
+// expect(metadata.favicons[4].color).toBe('#000000')
+// })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -48,12 +48,12 @@ test('no error when favicons missing from page', async () => {
   }
 })
 
-// test('favicons', async () => {
-//   const url = 'https://www.bbc.com/news/uk-england-somerset-68179350'
-//   const metadata = await urlMetadata(url)
-// expect(metadata.favicons.length).toBe(5)
-// expect(metadata.favicons[0].rel).toBe('apple-touch-icon')
-// Safari pinned tab 'mask-icons' can have 'color' attribute:
-// expect(metadata.favicons[4].rel).toBe('mask-icon')
-// expect(metadata.favicons[4].color).toBe('#000000')
-// })
+test('favicons', async () => {
+  const url = 'https://www.bbc.com/news/uk-england-somerset-68179350'
+  const metadata = await urlMetadata(url)
+  expect(metadata.favicons.length).toBe(5)
+  expect(metadata.favicons[0].rel).toBe('apple-touch-icon')
+  // Safari pinned tab 'mask-icons' can have 'color' attribute:
+  expect(metadata.favicons[4].rel).toBe('mask-icon')
+  expect(metadata.favicons[4].color).toBe('#000000')
+})

--- a/test/json-ld.test.js
+++ b/test/json-ld.test.js
@@ -4,10 +4,18 @@ test('retrieves json-ld if url has it', async () => {
   const url = 'https://www.coindesk.com/twitter-systemically-important-financial-regulators'
   try {
     const metadata = await urlMetadata(url)
-    expect(typeof metadata.jsonld).toBe('object')
-    expect(typeof metadata.jsonld.headline).toBe('string')
-    expect(typeof metadata.jsonld.datePublished).toBe('string')
+    expect(typeof metadata.jsonld[0]).toBe('object')
+    expect(typeof metadata.jsonld[0].headline).toBe('string')
+    expect(typeof metadata.jsonld[0].datePublished).toBe('string')
   } catch (err) {
     expect(err).toBe(undefined)
   }
+})
+
+test('retrieves multiple json-ld objects if url has it', async () => {
+  const url = 'https://goout.net/cs/metronome-prague-2024/szpsfuw/'
+  const metadata = await urlMetadata(url)
+  expect(metadata.jsonld.length).toBe(2)
+  expect(metadata.jsonld[0]['@type']).toBe('Event')
+  expect(metadata.jsonld[1]['@type']).toBe('BreadcrumbList')
 })


### PR DESCRIPTION
Check one:
- [X] I am reporting a bug.

## Steps to reproduce (if bug):
1. Try https://goout.net/cs/metronome-prague-2024/szpsfuw/
2. Only the second jsonld object appears in returned metadata. Fix is a breaking change, needs major pkg vesion bump.

### Checklist:
- [X] update README (if applicable)
- [X] update CHANGELOG
- [n/a] update ROADMAP (if applicable)
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [X] /example-typescript: `npm run start`
- [X] package.json: bump version
