### PR TITLE
bugfix: conditional useAgent for vite builds & Node.js <v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+5.0.4
+- bugfix issue #99: conditional useAgent for vite (browser) builds & Node.js < v18
+
 5.0.3
 - improve README & readability UX
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Includes:
 
 v5.0.0+ Protects against:
 - infinite redirect loops
-- SSRF attacks via `request-filtering-agent` in Node.js v20+ environments (custom options available)
+- SSRF attacks via `request-filtering-agent` in Node.js v18+ environments (custom options available)
 
 More details in the `Returns` section below.
 
@@ -58,7 +58,7 @@ const options = {
 
   // to prevent SSRF attacks, this default option blocks requests
   // to private network & reserved IP addresses
-  // supported in Node.js v20.0+; other envs ignore silently
+  // supported in Node.js v18+; other envs ignore silently
   // https://www.npmjs.com/package/request-filtering-agent
   requestFilteringAgentOptions: undefined,
 

--- a/example-typescript/index.ts
+++ b/example-typescript/index.ts
@@ -8,7 +8,7 @@ import urlMetadata from 'url-metadata';
       mode: 'same-origin',
       includeResponseBody: true
     });
-    console.log('1/ metadata.html:', metadata);
+    console.log('2/ fetch local metadata.html:', metadata);
   } catch(err) {
     console.log(err);
   }
@@ -40,7 +40,7 @@ import urlMetadata from 'url-metadata';
     // pass null `url` param & response object as option
     const metadata = await urlMetadata(null, { parseResponseObject: response })
 
-    console.log('2/ html string:', metadata);
+    console.log('1/ html string:', metadata);
   } catch(err) {
     console.log(err);
   }

--- a/example-typescript/package.json
+++ b/example-typescript/package.json
@@ -11,7 +11,7 @@
     }
   },
   "dependencies": {
-    "url-metadata": "^5.0.3"
+    "url-metadata": "^5.0.4"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,24 @@
-const { useAgent } = require('request-filtering-agent')
+// Conditionally import useAgent from request-filtering-agent only in Node.js v18+ environments
+// or provide a no-op implementation in browser and older unsupported Node.js environments
+// https://www.npmjs.com/package/request-filtering-agent
+let useAgent
+try {
+  // Check if we're in a Node.js v18+ environment
+  if (typeof process !== 'undefined' &&
+      process.versions &&
+      process.versions.node &&
+      parseInt(process.versions.node.split('.')[0]) >= 18) {
+    // We're in Node.js v18+
+    const requestFilteringAgent = require('request-filtering-agent')
+    useAgent = requestFilteringAgent.useAgent
+  } else {
+    // We're in a browser or Node.js < v18
+    useAgent = (url, options) => undefined
+  }
+} catch (e) {
+  // Fallback to no-op if module can't be loaded
+  useAgent = (url, options) => undefined
+}
 const extractCharset = require('./lib/extract-charset')
 const parse = require('./lib/parse')
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-// Conditionally import useAgent from request-filtering-agent only in Node.js v18+ environments
-// or provide a no-op implementation in browser and older unsupported Node.js environments
+// Conditionally import `useAgent` from `request-filtering-agent`
+// only in Node.js v18+ environments; no-op for browser & older Node.js envs
 // https://www.npmjs.com/package/request-filtering-agent
 let useAgent
 try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Request a url and scrape the metadata from its HTML using Node.js or the browser.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes issue #99 
The fix no-ops `useAgent` imported from `request-filtering-agent` for environments that don't support it.
___

### Contributors checklist:
- [X] update README (if applicable)
- [X] update CHANGELOG (if applicable)
- [ ] update ROADMAP (if applicable)
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [X] ensure ts example works in /example-typescript: `npm run start`

### Maintainers checklist:
- [X] `npm run test` on the new PR branch
- [X] ensure ts example works in /example-typescript: `npm run start`
- [X] package.json: bump semver version, push commit to new PR branch on origin
- [ ] `squash and merge` PR to master
- [ ] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [ ] `npm publish ./`
