### PR TITLE
Feature: add basic performance metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+5.6.0
+- feature: add basic performance metrics (see main.js for specifics)
+
 5.5.1, 5.5.2, 5.5.3
 - update, improve README and /example-* for clarity
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Request a url and scrape the metadata from its HTML using Node.js or the browser
 ## **Includes:**
 - response headers
 - redirects
-- performance metrics
+- basic performance metrics
 - meta tags
 - hreflang
 - favicons

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Request a url and scrape the metadata from its HTML using Node.js or the browser
 
 ---
 ## **Includes:**
-- response headers
 - redirects
+- response headers
 - basic performance metrics
 - meta tags
 - hreflang
@@ -24,7 +24,7 @@ Request a url and scrape the metadata from its HTML using Node.js or the browser
 - img tags
 - automatic charset detection & decoding (optional)
 - the full response body as a string of html (optional)
-- [x402](https://www.x402.org/) "payment required" error support
+- [x402](https://www.x402.org/) error support w payment requirements
 
 **Security** - v5.1.0+ Protects against:
 - Infinite redirect loops
@@ -57,7 +57,7 @@ async function getMetadata(url) {
   }
 }
 
-const metadata = await getMetadata('https://en.wikipedia.org/wiki/Server-side_request_forgery');
+const metadata = await getMetadata('https://en.wikipedia.org/wiki/WHATWG');
 ```
 
 ### Options & Defaults
@@ -127,7 +127,7 @@ const options = {
 
 // Basic options usage
 try {
-  const url = 'https://en.wikipedia.org/wiki/Server-side_request_forgery';
+  const url = 'https://en.wikipedia.org/wiki/WHATWG';
   const metadata = await urlMetadata(url, options);
   console.log(metadata);
 } catch (err) {
@@ -141,7 +141,7 @@ try {
 // Alternate use-case: parse a Response object instead:
 try {
   // fetch the url in your own code
-  const response = await fetch('https://en.wikipedia.org/wiki/Server-side_request_forgery');
+  const response = await fetch('https://en.wikipedia.org/wiki/WHATWG');
   // pass the `response` object to be parsed for its metadata
   const metadata = await urlMetadata(null, {
     parseResponseObject: response

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Request a url and scrape the metadata from its HTML using Node.js or the browser
 ## **Includes:**
 - response headers
 - redirects
+- performance metrics
 - meta tags
 - hreflang
 - favicons

--- a/example-javascript-require/index.js
+++ b/example-javascript-require/index.js
@@ -22,9 +22,9 @@ const urlMetadata = require('url-metadata');
       }
     })
     // pass null `url` param & response object as option
-    const metadata = await urlMetadata(null, { parseResponseObject: response });
-    console.log('parse html string:', metadata);
+    const metadata = await urlMetadata(null, { parseResponseObject: response })
+    console.log('parse html string:', metadata)
   } catch (err) {
-    console.error(err);
+    console.error(err)
   }
-})();
+})()

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -17,6 +17,7 @@ function MetadataFields (options) {
     url: '', // final destination url in request chain
     responseStatusCode: undefined,
     responseHeaders: {},
+    performance: {},
     canonical: '',
     lang: '',
     hreflang: [],

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,6 +11,7 @@ const extractHeaders = require('./extract-headers')
 module.exports = function (
   requestUrl,
   redirects,
+  perf,
   destinationUrl,
   body,
   responseStatusCode,
@@ -30,6 +31,7 @@ module.exports = function (
   const metadata = new MetadataFields(options)
     .set({ requestUrl })
     .set({ redirects })
+    .set({ performance: perf })
     .set({ url: destinationUrl })
     .set(scrapedMetaTags)
     .set({ hreflang: scrapedHreflang })

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const extractCharset = require('./lib/extract-charset')
 const parse = require('./lib/parse')
 const createHttpError = require('./lib/http-error')
 
-// Monotonic clock when available (browsers + Node 16+), else wall clock.
+// Monotonic clock when available (browsers + Node 16+), else wall clock fallback.
 // Every perf value is a delta from the same source, so the two never mix.
 const now = (typeof performance !== 'undefined' && performance.now)
   ? () => performance.now()
@@ -79,13 +79,14 @@ module.exports = function (url, options, _fetch, useAgent) {
         compress: opts.compress
       }
 
-      // Mark hop start; remember the first one for redirect accounting
+      // Perf: mark hop start; remember the first one for redirect accounting
       const hopStart = now()
       if (overallStart === undefined) overallStart = hopStart
 
-      // Make the fetch request
+      // --> Make the fetch request <--
       const response = await _fetch(_url, requestOpts)
-      // `node-fetch` resolves once response headers arrive (body is a stream),
+
+      // Perf: `node-fetch` resolves once response headers arrive (body is a stream),
       // so this is effectively time-to-first-byte for this hop
       const headersAt = now()
 
@@ -103,10 +104,10 @@ module.exports = function (url, options, _fetch, useAgent) {
         return fetchData(newUrl, redirectCount + 1)
       }
 
-      // Last hop reached: record timings relative to this hop only
+      // Perf: last hop reached; record timings relative to this hop only
       lastHopStart = hopStart
       perf.ttfbMs = Math.round(headersAt - hopStart)
-      // Redirect tax = everything that elapsed before the last hop began
+      // Perf: redirect tax = everything that elapsed before the last hop began
       if (redirects.count > 0) perf.redirectTimeMs = Math.round(hopStart - overallStart)
 
       // Finally, return the response
@@ -181,7 +182,8 @@ module.exports = function (url, options, _fetch, useAgent) {
       })
       .then(async (responseBuffer) => {
         if (!responseBuffer) return
-        // Body fully read here (arrayBuffer resolved). Same last-hop baseline as
+
+        // Perf: body fully read here (arrayBuffer resolved). Same last-hop baseline as
         // ttfbMs, so responseTimeMs - ttfbMs cleanly yields body download time
         if (lastHopStart !== undefined) perf.responseTimeMs = Math.round(now() - lastHopStart)
 

--- a/main.js
+++ b/main.js
@@ -2,6 +2,12 @@ const extractCharset = require('./lib/extract-charset')
 const parse = require('./lib/parse')
 const createHttpError = require('./lib/http-error')
 
+// Monotonic clock when available (browsers + Node 16+), else wall clock.
+// Every perf value is a delta from the same source, so the two never mix.
+const now = (typeof performance !== 'undefined' && performance.now)
+  ? () => performance.now()
+  : () => Date.now()
+
 module.exports = function (url, options, _fetch, useAgent) {
   if (!options || typeof options !== 'object') options = {}
 
@@ -41,6 +47,8 @@ module.exports = function (url, options, _fetch, useAgent) {
     ttfbMs: undefined, // last hop -> headers
     responseTimeMs: undefined // last hop start -> body read complete
   }
+  let overallStart // start of the very first hop
+  let lastHopStart // start of the final (non-redirect) hop
   let contentType
   let charset
   let currentResponse = null
@@ -71,8 +79,15 @@ module.exports = function (url, options, _fetch, useAgent) {
         compress: opts.compress
       }
 
+      // Mark hop start; remember the first one for redirect accounting
+      const hopStart = now()
+      if (overallStart === undefined) overallStart = hopStart
+
       // Make the fetch request
       const response = await _fetch(_url, requestOpts)
+      // `node-fetch` resolves once response headers arrive (body is a stream),
+      // so this is effectively time-to-first-byte for this hop
+      const headersAt = now()
 
       // If response is 3xx redirect
       if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
@@ -87,6 +102,12 @@ module.exports = function (url, options, _fetch, useAgent) {
         const newUrl = new URL(response.headers.get('location'), _url).href
         return fetchData(newUrl, redirectCount + 1)
       }
+
+      // Last hop reached: record timings relative to this hop only
+      lastHopStart = hopStart
+      perf.ttfbMs = Math.round(headersAt - hopStart)
+      // Redirect tax = everything that elapsed before the last hop began
+      if (redirects.count > 0) perf.redirectTimeMs = Math.round(hopStart - overallStart)
 
       // Finally, return the response
       return response
@@ -160,6 +181,9 @@ module.exports = function (url, options, _fetch, useAgent) {
       })
       .then(async (responseBuffer) => {
         if (!responseBuffer) return
+        // Body fully read here (arrayBuffer resolved). Same last-hop baseline as
+        // ttfbMs, so responseTimeMs - ttfbMs cleanly yields body download time
+        if (lastHopStart !== undefined) perf.responseTimeMs = Math.round(now() - lastHopStart)
 
         // Handle optional user-specified charset
         if (opts.decode !== 'auto') {
@@ -177,6 +201,7 @@ module.exports = function (url, options, _fetch, useAgent) {
           resolve(parse(
             requestUrl,
             redirects,
+            perf,
             finalUrl,
             responseDecoded,
             currentResponse.status,

--- a/main.js
+++ b/main.js
@@ -36,6 +36,11 @@ module.exports = function (url, options, _fetch, useAgent) {
     count: 0,
     chain: []
   }
+  const perf = {
+    redirectTimeMs: undefined, // redirect tax before last hop
+    ttfbMs: undefined, // last hop -> headers
+    responseTimeMs: undefined // last hop start -> body read complete
+  }
   let contentType
   let charset
   let currentResponse = null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "5.5.3",
+  "version": "5.6.0",
   "description": "Request a url and scrape the metadata from its HTML using Node.js or the browser.",
   "keywords": [
     "html",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,6 +5,14 @@ test('basic https:// fetch', async () => {
   try {
     const metadata = await urlMetadata(url)
     expect(metadata.requestUrl).toBe(url)
+    expect(metadata.responseStatusCode).toBe(200)
+    expect(typeof metadata.responseHeaders).toBe('object')
+    expect(metadata.responseHeaders['content-type']).toContain('text/html')
+    expect(metadata.redirects).toBeDefined()
+    expect(metadata.redirects.count).toBe(0)
+    expect(metadata.redirects.chain.length).toBe(0)
+    expect(metadata.performance).toBeDefined()
+    expect(metadata.performance.redirectTimeMs).toBe(undefined) // invariant test; no redirects expected
     expect(metadata.url).toContain(url)
     expect(metadata.title).toContain('SEO')
     expect(metadata.lang).toBe('en')
@@ -21,9 +29,6 @@ test('basic https:// fetch', async () => {
     expect(metadata.jsonld.length).toBeGreaterThan(0)
     expect(metadata.headings.length).toBeGreaterThan(3)
     expect(metadata.headings[0].level).toBe('h1')
-    expect(metadata.responseStatusCode).toBe(200)
-    expect(typeof metadata.responseHeaders).toBe('object')
-    expect(metadata.responseHeaders['content-type']).toContain('text/html')
   } catch (err) {
     expect(err).toBe(undefined)
   }

--- a/test/redirect-perf.test.js
+++ b/test/redirect-perf.test.js
@@ -1,6 +1,6 @@
 const urlMetadata = require('./../index')
 
-test('follow redirects by default; metadata has redirects property w correct shape', async () => {
+test('follow redirects by default; redirects + performance props have correct shape', async () => {
   const url = 'https://t.co/3K2Oj1dRlE'
   try {
     const metadata = await urlMetadata(url)
@@ -14,6 +14,11 @@ test('follow redirects by default; metadata has redirects property w correct sha
     expect(metadata.redirects.chain[0].statusCode).toBeGreaterThan(300)
     expect(metadata.redirects.chain[0].statusCode).toBeLessThan(400)
     expect(metadata.redirects.chain[0].url).toBe(url)
+    // Test metadata.performance shape
+    expect(metadata.performance).toBeDefined()
+    expect(metadata.performance.redirectTimeMs).toBeGreaterThan(0)
+    expect(metadata.performance.ttfbMs).toBeGreaterThan(0)
+    expect(metadata.performance.responseTimeMs).toBeGreaterThan(metadata.performance.ttfbMs)
   } catch (err) {
     expect(err).toBe(undefined)
   }
@@ -48,6 +53,7 @@ test('https:// -> http:// redirect success', async () => {
     const url = 'https://bit.ly/4uIArop'
     const metadata = await urlMetadata(url, { maxRedirects: 2 })
     expect(metadata.redirects.count).toBeGreaterThan(0)
+    expect(metadata.performance).toBeDefined()
   } catch (err) {
     expect(err).toBe(undefined)
   }
@@ -58,6 +64,11 @@ test('http:// -> https:// redirect success', async () => {
     const url = 'http://bit.ly/4oFgU6Q'
     const metadata = await urlMetadata(url)
     expect(metadata.redirects.count).toBeGreaterThan(0)
+    // Test metadata.performance shape
+    expect(metadata.performance).toBeDefined()
+    expect(metadata.performance.redirectTimeMs).toBeGreaterThan(0)
+    expect(metadata.performance.ttfbMs).toBeGreaterThan(0)
+    expect(metadata.performance.responseTimeMs).toBeGreaterThan(metadata.performance.ttfbMs)
   } catch (err) {
     expect(err).toBe(undefined)
   }


### PR DESCRIPTION
### Feature request:
add basic performance metrics to metadata, see main.js for implementation details:
```js
  const perf = {
    redirectTimeMs: undefined, // redirect tax before last hop
    ttfbMs: undefined, // last hop -> headers
    responseTimeMs: undefined // last hop start -> body read complete
  }
```
___

### Contributors checklist:
- [X] update README (if applicable)
- [X] update CHANGELOG (if applicable)
- [ ] update ROADMAP (if applicable)
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [X] ensure ts example works in /example-typescript: `npm run start`
- [X] ensure vite.js example works in /example-vite: `npm run dev`

### Maintainers checklist:
- [ ] `npm run test` on the new PR branch
- [ ] ensure ts example works in /example-typescript: `npm run start`
- [ ] ensure vite.js example works in /example-vite: `npm run dev`
- [ ] package.json: bump semver version, push commit to new PR branch on origin
- [ ] `squash and merge` PR to master
- [ ] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [ ] `npm publish ./`
