### PR TITLE
security: strip sensitive headers on redirect to diff host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+5.7.3
+- bugfix: #112 - security: strip sensitive headers on redirect to diff host
+
 5.7.2
 - bugfix: `performance.ttfb` now cumulative, includes `redirectTimeMs` per Google web.dev definition
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Has optional m
 - Infinite redirect loops: `maxRedirects` option defaults to 10.
 - SSRF attacks via [request-filtering-agent](https://www.npmjs.com/package/request-filtering-agent) in Node.js v18+ (custom options also available)
 - Memory-exhaustion attacks (gzip bombs, oversized responses): set `size` option. Pair with `timeout` to prevent slow/connection-holding responses.
+- Leaking sensitive headers (auth, cookies) if target URL redirects to a diff host.
 
 More details below. To report a bug or request a feature please open an issue or pull request in [GitHub](https://github.com/laurengarcia/url-metadata). Please read the `Troubleshooting` section below *before* filing a bug.
 

--- a/main.js
+++ b/main.js
@@ -8,6 +8,10 @@ const now = (typeof performance !== 'undefined' && performance.now)
   ? () => performance.now()
   : () => Date.now()
 
+// Credential-bearing headers dropped when a redirect hop changes host,
+// mirroring browsers & `node-fetch` >=2.6.7 (CVE-2022-0235 class)
+const sensitiveHeaders = ['authorization', 'www-authenticate', 'cookie', 'cookie2']
+
 module.exports = function (url, options, _fetch, useAgent) {
   if (!options || typeof options !== 'object') options = {}
 
@@ -52,7 +56,7 @@ module.exports = function (url, options, _fetch, useAgent) {
   let charset
   let currentResponse = null
 
-  async function fetchData (_url, redirectCount = 0) {
+  async function fetchData (_url, redirectCount = 0, requestHeaders = opts.requestHeaders) {
     if (redirectCount > opts.maxRedirects) {
       throw createHttpError({ msg: 'too many redirects', redirects, requestUrl, url: _url })
     }
@@ -64,7 +68,7 @@ module.exports = function (url, options, _fetch, useAgent) {
     } else if (_url) {
       const requestOpts = {
         method: 'GET',
-        headers: opts.requestHeaders,
+        headers: requestHeaders,
         // If the user doesn't pass in their own agent:
         // When agent is a function, `node-fetch` calls it with the parsed URL
         // of the request it's about to make, and uses the return value as the
@@ -98,9 +102,18 @@ module.exports = function (url, options, _fetch, useAgent) {
           url: _url,
           statusCode: response.status
         })
-        // Then, follow the redirect
+        // Then, follow the redirect. Strip sensitive headers when the hop
+        // crosses hosts; once stripped they stay stripped for later hops.
         const newUrl = new URL(response.headers.get('location'), _url).href
-        return fetchData(newUrl, redirectCount + 1)
+        let nextHeaders = requestHeaders
+        // Compare exact host - its what browsers, curl, unidici do
+        if (new URL(newUrl).host !== new URL(_url).host) {
+          nextHeaders = {}
+          for (const key of Object.keys(requestHeaders)) {
+            if (!sensitiveHeaders.includes(key.toLowerCase())) nextHeaders[key] = requestHeaders[key]
+          }
+        }
+        return fetchData(newUrl, redirectCount + 1, nextHeaders)
       }
 
       // Perf: last hop reached (the first non-redirect response). ttfbMs and

--- a/test/redirect-perf.test.js
+++ b/test/redirect-perf.test.js
@@ -125,12 +125,15 @@ test('strips sensitive headers on cross-host redirect hops only', async () => {
   expect(metadata.redirects.count).toBe(2)
   expect(hops.length).toBe(3)
   // Hop 1 (original request): all headers present
+  expect(hops[0].url).toBe('https://origin.example.com/start') // original request
   expect(hops[0].headers.Authorization).toBe('Bearer hunter2')
   expect(hops[0].headers.Cookie).toBe('session=abc123')
   // Hop 2 (same host): credentials still forwarded
+  expect(hops[1].url).toBe('https://origin.example.com/step') // 1st hop: same host
   expect(hops[1].headers.Authorization).toBe('Bearer hunter2')
   expect(hops[1].headers.Cookie).toBe('session=abc123')
   // Hop 3 (cross host): credentials stripped, benign headers kept
+  expect(hops[2].url).toBe('https://elsewhere.example.net/final') // 2nd hop: diff host
   expect(hops[2].headers.Authorization).toBe(undefined)
   expect(hops[2].headers.Cookie).toBe(undefined)
   expect(hops[2].headers['User-Agent']).toBe('url-metadata test')

--- a/test/redirect-perf.test.js
+++ b/test/redirect-perf.test.js
@@ -1,4 +1,5 @@
 const urlMetadata = require('./../index')
+const main = require('./../main')
 
 test('follow redirects by default; redirects + performance props have correct shape', async () => {
   const url = 'https://t.co/3K2Oj1dRlE'
@@ -75,6 +76,64 @@ test('http:// -> https:// redirect success', async () => {
   } catch (err) {
     expect(err).toBe(undefined)
   }
+})
+
+test('strips sensitive headers on cross-host redirect hops only', async () => {
+  // Mock fetch: same-host hop, then cross-host hop, then 200 html.
+  // Records the headers each hop receives.
+  const hops = []
+  const mockHeaders = (obj) => {
+    const map = new Map(Object.entries(obj))
+    return {
+      get: (k) => (map.has(k.toLowerCase()) ? map.get(k.toLowerCase()) : null),
+      forEach: (fn) => map.forEach(fn)
+    }
+  }
+  const routes = {
+    'https://origin.example.com/start': {
+      status: 301,
+      headers: mockHeaders({ location: 'https://origin.example.com/step' })
+    },
+    'https://origin.example.com/step': {
+      status: 301,
+      headers: mockHeaders({ location: 'https://elsewhere.example.net/final' })
+    },
+    'https://elsewhere.example.net/final': {
+      status: 200,
+      ok: true,
+      url: 'https://elsewhere.example.net/final',
+      headers: mockHeaders({ 'content-type': 'text/html; charset=utf-8' }),
+      arrayBuffer: async () => new TextEncoder().encode(
+        '<html><head><title>ok</title></head><body></body></html>'
+      ).buffer
+    }
+  }
+  const mockFetch = async (url, requestOpts) => {
+    hops.push({ url, headers: requestOpts.headers })
+    return routes[url]
+  }
+  const noopAgent = () => undefined
+
+  const metadata = await main('https://origin.example.com/start', {
+    requestHeaders: {
+      'User-Agent': 'url-metadata test',
+      Authorization: 'Bearer hunter2',
+      Cookie: 'session=abc123'
+    }
+  }, mockFetch, noopAgent)
+
+  expect(metadata.redirects.count).toBe(2)
+  expect(hops.length).toBe(3)
+  // Hop 1 (original request): all headers present
+  expect(hops[0].headers.Authorization).toBe('Bearer hunter2')
+  expect(hops[0].headers.Cookie).toBe('session=abc123')
+  // Hop 2 (same host): credentials still forwarded
+  expect(hops[1].headers.Authorization).toBe('Bearer hunter2')
+  expect(hops[1].headers.Cookie).toBe('session=abc123')
+  // Hop 3 (cross host): credentials stripped, benign headers kept
+  expect(hops[2].headers.Authorization).toBe(undefined)
+  expect(hops[2].headers.Cookie).toBe(undefined)
+  expect(hops[2].headers['User-Agent']).toBe('url-metadata test')
 })
 
 test('errors properly when redirect is blocked', async () => {


### PR DESCRIPTION
# Check one:
- [X] I am reporting a bug.

### Steps to reproduce (if bug):
It's a corner case, and not how i intended this module to be used, but if a user passes in a URL with sensitive custom headers via `option.requestHeaders` and the URL is redirected to a different host, the sensitive headers could be leaked to the different host.

Solution is strip sensitive headers when the module detects its been redirected away from the intended host.
___

### Contributors checklist:
- [X] update README (if applicable)
- [X] update CHANGELOG (if applicable)
- [ ] update ROADMAP (if applicable)
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [ ] ensure ts example works in /example-typescript: `npm run start`
- [ ] ensure vite.js example works in /example-vite: `npm run dev`

### Maintainers checklist:
- [X] `npm run test` on the new PR branch
- [ ] ensure ts example works in /example-typescript: `npm run start`
- [ ] ensure vite.js example works in /example-vite: `npm run dev`
- [X] package.json: bump semver version, push commit to new PR branch on origin
- [X] `squash and merge` PR to master
- [X] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [X] `npm publish ./`
