### PR TITLE
Define opt-in KnownFields & KnownFieldsStrict for Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,18 +200,18 @@ The object consists of key/value pairs as strings, with exceptions:
 
 
 ### TypeScript
-The default return type `Result` is intentionally loose (collapses to `any`) so that existing codebases, mocks, and defensive scraping code compile untouched. If you want a documented, autocompleting shape, opt in with a cast — no runtime change:
+The default return type `Result` is intentionally loose (collapses to `any`) so that existing codebases, mocks, and defensive scraping code compile untouched. If you want a documented, autocompleting shape, opt in with a cast. No runtime change needed:
 
 ```ts
 import urlMetadata from 'url-metadata';
 
 // Known fields fully typed; any extra page-specific
 // meta tags fall through to `any`:
-const meta = await urlMetadata(url) as urlMetadata.KnownFields;
-meta.title;      // string
-meta.favicons;   // FaviconTag[]
-meta.redirects;  // { count: number, chain: RedirectHop[] }
-meta.foobar;     // any (arbitrary meta tag found on page)
+const metadata = await urlMetadata(url) as urlMetadata.KnownFields;
+metadata.title;      // string
+metadata.favicons;   // FaviconTag[]
+metadata.redirects;  // { count: number, chain: RedirectHop[] }
+metadata.foobar;     // any (arbitrary meta tag found on page; mostly returns as string)
 
 // Strictest variant: known fields ONLY, closed shape.
 // Catches typos at compile time, but arbitrary page-specific
@@ -219,7 +219,7 @@ meta.foobar;     // any (arbitrary meta tag found on page)
 const strict = await urlMetadata(url) as urlMetadata.KnownFieldsStrict;
 ```
 
-See `index.d.ts` for the full field catalog and the exported `HreflangTag`, `FaviconTag`, `Heading`, `ImgTag`, and `RedirectHop` interfaces.
+See `index.d.ts` for the full field catalog and the other exported interfaces: `HreflangTag`, `FaviconTag`, `Heading`, `ImgTag`, and `RedirectHop`.
 
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -199,6 +199,29 @@ The object consists of key/value pairs as strings, with exceptions:
 ```
 
 
+### TypeScript
+The default return type `Result` is intentionally loose (collapses to `any`) so that existing codebases, mocks, and defensive scraping code compile untouched. If you want a documented, autocompleting shape, opt in with a cast — no runtime change:
+
+```ts
+import urlMetadata from 'url-metadata';
+
+// Known fields fully typed; any extra page-specific
+// meta tags fall through to `any`:
+const meta = await urlMetadata(url) as urlMetadata.KnownFields;
+meta.title;      // string
+meta.favicons;   // FaviconTag[]
+meta.redirects;  // { count: number, chain: RedirectHop[] }
+meta.foobar;     // any (arbitrary meta tag found on page)
+
+// Strictest variant: known fields ONLY, closed shape.
+// Catches typos at compile time, but arbitrary page-specific
+// meta tags (incl. `citation_*`) are compile errors:
+const strict = await urlMetadata(url) as urlMetadata.KnownFieldsStrict;
+```
+
+See `index.d.ts` for the full field catalog and the exported `HreflangTag`, `FaviconTag`, `Heading`, `ImgTag`, and `RedirectHop` interfaces.
+
+
 ### Troubleshooting
 
 **Issue:** Request returns `404`, `403` errors or a CAPTCHA form. Your request may have been blocked by the server because it suspects you are a bot or scraper. Check [this list](https://dev.to/princepeterhansen/7-ways-to-avoid-getting-blocked-or-blacklisted-when-web-scraping-45ii) to ensure you're not triggering a block.

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,22 @@ declare namespace urlMetadata {
     parseResponseObject?: globalThis.Response | import('node-fetch').Response;
   }
 
+  interface UrlMetadataError extends Error {
+    requestUrl?: string; // the url the user passed in
+    redirects?: { // included in all errors where applicable (some do not reach this point tho)
+      count: number;
+      chain: RedirectHop[];
+    };
+    url?: string; // final destination url in request chain
+    statusCode?: number;
+    paymentRequired?: boolean;
+    x402?: Record<string, any>; // x402 payment requirements - https://www.x402.org/
+    // errors that *may* fall thru from `node-fetch` dependency in Node.js v18+:
+    type?: string;
+    errno?: string;
+    code?: string;
+  }
+
   /**
    * Intentionally loose (collapses to `any`) for maximum compatibility.
    * For a documented shape, opt in with:
@@ -31,10 +47,21 @@ declare namespace urlMetadata {
   type Result = Record<string, string | boolean | number | undefined | any | any[]>;
 
   /**
+   * Opt-in documented result shape:
+   *   const metadata = await urlMetadata(url) as urlMetadata.KnownFields;
+   * Known fields are fully typed; any additional meta tags found on the
+   * page are appended as new fields, as strings — except tags starting
+   * with `citation_`, which are string[] (per Google Scholar spec, see README).
+   */
+  interface KnownFields extends KnownFieldsStrict {
+    [metaTagName: string]: any;
+  }
+
+  /**
    * The complete catalog of fields always present on a successful result
    * (see lib/metadata-fields.js). Closed: no index signature, so `keyof`
    * yields the literal field-name union. Most users want `KnownFields`
-   * below instead.
+   * instead, which allows arbitrary meta tags to be included in definition.
    */
   interface KnownFieldsStrict {
     requestUrl: string; // the url the user passed in
@@ -51,7 +78,7 @@ declare namespace urlMetadata {
       redirectTimeMs?: number; // only set when redirects occurred
     };
     canonical: string; // first <link rel="canonical"> found, '' if none
-    canonicalUrls: string[]; // raw href of every canonical tag, in document order
+    canonicalUrls: string[]; // raw href of every canonical tag, in document order, if more than 1 found
     lang: string;
     hreflang: HreflangTag[];
     charset: string;
@@ -131,20 +158,6 @@ declare namespace urlMetadata {
     responseBody: string; // '' unless options.includeResponseBody is true
   }
 
-  /**
-   * Opt-in documented result shape:
-   *   const metadata = await urlMetadata(url) as urlMetadata.KnownFields;
-   * Known fields are fully typed; anything else falls through to `any`.
-   */
-  interface KnownFields extends KnownFieldsStrict {
-    /**
-     * Any additional meta tags found on the page are appended as new
-     * fields, as strings — except tags starting with `citation_`,
-     * which are string[] (per Google Scholar spec, see README).
-     */
-    [metaTagName: string]: any;
-  }
-
   interface HreflangTag {
     hreflang: string;
     href?: string;
@@ -177,19 +190,4 @@ declare namespace urlMetadata {
     statusCode: number; // the 3xx status returned by this hop
   }
 
-  interface UrlMetadataError extends Error {
-    requestUrl?: string; // the url the user passed in
-    redirects?: { // included in all errors where applicable (some do not reach this point tho)
-      count: number;
-      chain: RedirectHop[]
-    };
-    url?: string; // final destination url in request chain
-    statusCode?: number;
-    paymentRequired?: boolean;
-    x402?: Record<string, any>; // x402 payment requirements - https://www.x402.org/
-    // errors that *may* fall thru from `node-fetch` dependency in Node.js v6+:
-    type?: string;
-    errno?: string;
-    code?: string;
-  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,153 @@ declare namespace urlMetadata {
     parseResponseObject?: globalThis.Response | import('node-fetch').Response;
   }
 
+  /**
+   * Intentionally loose (collapses to `any`) for maximum compatibility.
+   * For a documented shape, opt in with:
+   *   const metadata = await urlMetadata(url) as urlMetadata.KnownFields;
+   */
   type Result = Record<string, string | boolean | number | undefined | any | any[]>;
+
+  /**
+   * The complete catalog of fields always present on a successful result
+   * (see lib/metadata-fields.js). Closed: no index signature, so `keyof`
+   * yields the literal field-name union. Most users want `KnownFields`
+   * below instead.
+   */
+  interface KnownFieldsStrict {
+    requestUrl: string; // the url the user passed in
+    redirects: {
+      count: number;
+      chain: RedirectHop[];
+    };
+    url: string; // final destination url in request chain
+    responseStatusCode: number;
+    responseHeaders: Record<string, string>; // whitelisted set, see lib/extract-headers.js
+    performance: {
+      ttfbMs?: number; // cumulative: first request start -> final hop's headers arriving
+      responseTimeMs?: number; // cumulative: first request start -> body read complete
+      redirectTimeMs?: number; // only set when redirects occurred
+    };
+    canonical: string; // first <link rel="canonical"> found, '' if none
+    canonicalUrls: string[]; // raw href of every canonical tag, in document order
+    lang: string;
+    hreflang: HreflangTag[];
+    charset: string;
+    viewport: string;
+    title: string;
+    'application-name': string;
+    favicons: FaviconTag[];
+    image: string;
+    description: string;
+    keywords: string;
+    referrer: string;
+    author: string;
+    publisher: string;
+    creator: string;
+    source: string;
+    robots: string;
+    googlebot: string;
+    generator: string;
+    'color-scheme': string;
+    'theme-color': string;
+    price: string;
+    priceCurrency: string;
+    availability: string;
+    jsonld: Record<string, any>[]; // arbitrary schema.org shapes, per-site
+
+    // http://ogp.me/
+    'og:url': string;
+    'og:locale': string;
+    'og:locale:alternate': string;
+    'og:title': string;
+    'og:type': string;
+    'og:description': string;
+    'og:determiner': string;
+    'og:site_name': string;
+    'og:image': string;
+    'og:image:alt': string;
+    'og:image:secure_url': string;
+    'og:image:type': string;
+    'og:image:width': string;
+    'og:image:height': string;
+    'product:brand': string;
+    'product:availability': string;
+    'product:condition': string;
+    'product:price:amount': string;
+    'product:price:currency': string;
+    'product:retailer_item_id': string;
+    'product:item_group_id': string;
+
+    // https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup
+    'twitter:title': string;
+    'twitter:description': string;
+    'twitter:image': string;
+    'twitter:image:alt': string;
+    'twitter:card': string;
+    'twitter:site': string;
+    'twitter:site:id': string;
+    'twitter:url': string;
+    'twitter:account_id': string;
+    'twitter:creator': string;
+    'twitter:creator:id': string;
+    'twitter:player': string;
+    'twitter:player:width': string;
+    'twitter:player:height': string;
+    'twitter:player:stream': string;
+    'twitter:app:name:iphone': string;
+    'twitter:app:id:iphone': string;
+    'twitter:app:url:iphone': string;
+    'twitter:app:name:ipad': string;
+    'twitter:app:id:ipad': string;
+    'twitter:app:url:ipad': string;
+    'twitter:app:name:googleplay': string;
+    'twitter:app:id:googleplay': string;
+    'twitter:app:url:googleplay': string;
+
+    headings: Heading[];
+    imgTags: ImgTag[];
+    responseBody: string; // '' unless options.includeResponseBody is true
+  }
+
+  /**
+   * Opt-in documented result shape:
+   *   const metadata = await urlMetadata(url) as urlMetadata.KnownFields;
+   * Known fields are fully typed; anything else falls through to `any`.
+   */
+  interface KnownFields extends KnownFieldsStrict {
+    /**
+     * Any additional meta tags found on the page are appended as new
+     * fields, as strings — except tags starting with `citation_`,
+     * which are string[] (per Google Scholar spec, see README).
+     */
+    [metaTagName: string]: any;
+  }
+
+  interface HreflangTag {
+    hreflang: string;
+    href?: string;
+  }
+
+  interface FaviconTag {
+    rel: string;
+    type?: string;
+    href?: string;
+    sizes?: string;
+    color?: string; // only set when rel is 'mask-icon'
+  }
+
+  interface Heading {
+    level: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    text: string;
+  }
+
+  interface ImgTag {
+    src?: string;
+    alt?: string;
+    title?: string;
+    width?: string;
+    height?: string;
+  }
 
   interface RedirectHop {
     order: number; // 1-based position in the chain (first hop is order: 1)

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -43,7 +43,7 @@ function MetadataFields (options) {
     price: '',
     priceCurrency: '',
     availability: '',
-    jsonld: [],
+    jsonld: [], // arbitrary schema.org shapes, per-site
 
     // http://ogp.me/
     'og:url': '',
@@ -96,7 +96,7 @@ function MetadataFields (options) {
 
     headings: [],
     imgTags: [],
-    responseBody: ''
+    responseBody: '' // '' unless options.includeResponseBody is true
   }
 
   return this

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -15,11 +15,11 @@ function MetadataFields (options) {
     requestUrl: '', // the url the user passed in
     redirects: {},
     url: '', // final destination url in request chain
-    responseStatusCode: undefined,
-    responseHeaders: {},
+    responseStatusCode: undefined, // always populated by end of success result
+    responseHeaders: {}, // whitelisted set, see lib/extract-headers.js
     performance: {},
     canonical: '',
-    canonicalUrls: [],
+    canonicalUrls: [], // raw href of every canonical tag, in document order, if more than 1 found
     lang: '',
     hreflang: [],
     charset: '',

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,7 +21,7 @@ module.exports = function (
 ) {
   const $ = cheerio.load(body)
   const title = $('head title').text()
-  const lang = $('html').attr('lang')
+  const lang = $('html').attr('lang') || ''
   const scrapedHreflang = extractHreflang($)
   const scrapedCanonical = extractCanonical($)
   const scrapedMetaTags = extractMetaTags($)

--- a/test/type-drift.test.js
+++ b/test/type-drift.test.js
@@ -1,0 +1,50 @@
+/**
+ * Drift protection: the KnownFieldsStrict interface in index.d.ts must
+ * stay in sync with the runtime seed object in lib/metadata-fields.js.
+ * Two-source invariant — if you add/remove a field in one, update the other.
+ *
+ * Parses index.d.ts textually (skip TypeScript tooling) by
+ * extracting top-level keys from the KnownFieldsStrict block.
+ */
+const fs = require('fs')
+const path = require('path')
+const MetadataFields = require('../lib/metadata-fields')
+
+/**
+ * Extracts top-level property names from the KnownFieldsStrict interface.
+ * Matches keys at exactly 4-space indent (nested object props sit at 6+),
+ * both bare (requestUrl) and quoted ('og:url') forms.
+ * @returns {string[]}
+ */
+function extractDtsKeys () {
+  const dts = fs.readFileSync(path.join(__dirname, '..', 'index.d.ts'), 'utf8')
+
+  const start = dts.indexOf('interface KnownFieldsStrict {')
+  expect(start).toBeGreaterThan(-1) // interface renamed/removed? update this test
+
+  // block ends at the first closing brace at 2-space indent after start
+  const end = dts.indexOf('\n  }', start)
+  expect(end).toBeGreaterThan(start)
+
+  const block = dts.slice(start, end)
+  const keyPattern = /^ {4}(?:'([^']+)'|([A-Za-z][\w-]*))\??:/
+  const keys = []
+
+  block.split('\n').forEach(function (line) {
+    const match = line.match(keyPattern)
+    if (match) keys.push(match[1] || match[2])
+  })
+
+  return keys
+}
+
+test('index.d.ts KnownFieldsStrict matches lib/metadata-fields.js seed object', () => {
+  const dtsKeys = extractDtsKeys().sort()
+  const runtimeKeys = Object.keys(new MetadataFields({}).fields).sort()
+
+  // sanity: the parser actually found the catalog, not an empty block
+  expect(dtsKeys.length).toBeGreaterThan(30)
+
+  // symmetric diff via array equality — jest prints the exact delta on failure
+  expect(dtsKeys).toEqual(runtimeKeys)
+})


### PR DESCRIPTION
Define opt-in `KnownFields` & `KnownFieldsStrict` for Typescript. This is in preparation for adding an `{ option: { fields: "" } }` as requested in #62 

- `index.d.ts` — KnownFieldsStrict catalog + KnownFields (`any` index sig) + HreflangTag/FaviconTag/Heading/ImgTag, Result untouched with pointer JSDoc, UrlMetadataError first as file is read. 
- README.md — TypeScript opt-in section.
- `test/type-drift.test.js` — two-source invariant, passing.

Also found:
- bugfix: `lang: string` is now true (could have returned `undefined` before in `lib/parse.js`)

___

### Contributors checklist:
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [X] ensure ts example works in /example-typescript: `npm run start`
- [X] ensure vite.js example works in /example-vite: `npm run dev`

### Maintainers checklist:
- [X] update README (if applicable)
- [X] update CHANGELOG (if applicable)
- [X] update ROADMAP (if applicable)
- [x] `npm run test` on the new PR branch
- [X] optional: test examples against packed local .tgz file
  - [X] `npm pack`
  - [X] `cd /example-typescript` then `npm install ../url-metadata-<version>.tgz`
  - [X] build & start, ensure no errors
  - [X] do same for other `/example-*` dirs
- [X] package.json: bump semver version, push commit to new PR branch on origin
- [X] `squash and merge` PR to master
- [X] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [X] `npm publish ./`
