### PR TITLE
User-selected `fields` option, `omitEmpty` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+5.8.2
+- README: add Feedback Form
+
 5.8.1
 - README updates & tests for ScrapingAnt proxy integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+5.9.0
+- new option: `omitEmpty: true` purges empty fields from result
+- new option: `fields: []` accepts named groups or atomic field names
+
 5.8.2
 - README: add Feedback Form
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Has optional m
 - **parser mode** - pass in an html string or Response object (optional)
 - automatic charset detection & decoding (optional)
 - [x402](https://www.x402.org/) errors return payment requirements
-- [Discord](https://discord.gg/BqVBeeGsc5) support channel
+- 📬 [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) and [Discord](https://discord.gg/BqVBeeGsc5) support channel
 
 ## **Extracts:**
 - redirects
@@ -319,4 +319,4 @@ const strict = await urlMetadata(url) as urlMetadata.KnownFieldsStrict;
 👉 You may also want to try the hosted version of this package: [Minifetch](https://www.npmjs.com/package/minifetch-api).
 
 ---
-
+📬 Get in touch: [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [Github Issues](https://github.com/laurengarcia/url-metadata/issues)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Optional mode 
 - **parser mode** - pass in an html string or Response object (optional)
 - automatic charset detection & decoding (optional)
 - [x402](https://www.x402.org/) errors return payment requirements
-- 📬 [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [GitHub](https://github.com/laurengarcia/url-metadata) actively monitored
+- 📫 Actively monitored [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [GitHub](https://github.com/laurengarcia/url-metadata)
 
 ## **Extracts:**
 - redirects
@@ -385,4 +385,4 @@ partial.responseStatusCode; // number | undefined
 👉 You may also want to try the hosted version of this package: [Minifetch](https://www.npmjs.com/package/minifetch-api).
 
 ---
-📬 Get in touch: [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [Github Issues](https://github.com/laurengarcia/url-metadata/issues)
+📫 Get in touch: [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [Github Issues](https://github.com/laurengarcia/url-metadata/issues)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # url-metadata
 
-Fetch a URL and scrape its metadata using Node.js or the browser. Has optional mode to parse metadata from HTML strings or `Response` objects instead. First-class configurable security options available. Content is returned raw by design; sanitize your own output (so you control processing efficiency).
+Fetch a URL and scrape its metadata using Node.js or the browser. Optional mode to parse metadata from HTML strings or `Response` objects instead. You can also request just the fields you need for smaller responses and less extraction work, tuned for your use-case. First-class configurable security options available. Content is returned raw by design; sanitize your own output (so you control processing efficiency).
 
 ---
 <div>
-  👉 <i><strong>Looking for a quick hosted solution?</i> <a href="https://minifetch.com">Minifetch</a></strong> is an SEO toolkit built on top of this package by the same author/ maintainer. Get started free:
+  👉 <i><strong>Looking for a quick hosted solution?</i> <a href="https://minifetch.com">Minifetch</a></strong> is an extraction & SEO toolkit built on top of this package by the same author/ maintainer. Get started free:
   <a href="https://www.npmjs.com/package/minifetch-api">npm install minifetch-api</a>
 </div>
 
@@ -17,7 +17,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Has optional m
 - **parser mode** - pass in an html string or Response object (optional)
 - automatic charset detection & decoding (optional)
 - [x402](https://www.x402.org/) errors return payment requirements
-- 📬 [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) and [Discord](https://discord.gg/BqVBeeGsc5) support channel
+- 📬 [Feedback Form](https://forms.gle/UyXmzp596ZYzWCEH8) | [Discord](https://discord.gg/BqVBeeGsc5) | [GitHub](https://github.com/laurengarcia/url-metadata) actively monitored
 
 ## **Extracts:**
 - redirects
@@ -33,6 +33,12 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Has optional m
 - h1-h6 tags
 - img tags
 - the full response body as a string of html (optional)
+
+### Performance Tuning & Token-Efficiency
+- Use `fields` option to request only what you need
+- Shrinks the response size *and* skips the extra extraction work
+- Use `omitEmpty: true` option to drop empty fields
+- Customize for your specific use-case
 
 ### **🔒 Security** - Protects against:
 - Infinite redirect loops: `maxRedirects` option defaults to 10.
@@ -92,8 +98,19 @@ const options = {
   proxyParams: undefined,
 
   // Alternate use-case: pass `Response` object to be parsed
-  // See example usage below
+  // See example usage below.
   parseResponseObject: undefined,
+
+  // Request only what you need. Accepts atomic field names or named groups:
+  // ['network', 'meta', 'og', 'twitter']
+  // Also accepts specific meta tags with the "meta:<name>" syntax, ex:
+  // ['meta:description'] or ['meta:og:url']
+  // See "Performance Tuning" section below.
+  fields: undefined
+
+  // Drop empty fields (undefined, null, '', [], {}) from the returned
+  // object. Shallow: only top-level fields are removed.
+  omitEmpty: false
 
   // (Node.js v18.17+ only)
   // To prevent SSRF attacks, the default option blocks fetch
@@ -149,12 +166,6 @@ const options = {
 
   // Include raw response body as string
   includeResponseBody: false,
-
-  // Drop empty fields (undefined, null, '', [], {}) from the returned
-  // object for a smaller, more token-efficient response. Shallow: only
-  // top-level fields are removed. If you cast in Typescript, use:
-  // `Partial<urlMetadata.KnownFields>` (see below).
-  omitEmpty: false
 };
 
 // Options usage:
@@ -254,6 +265,8 @@ const metadata = await urlMetadata('https://hardto.get', {
 });
 ```
 
+### Performance Tuning
+
 ## Returns
 Returns a promise resolved with a JSON object. Note that the returned `url` field will be the last hop in the request chain if there are redirects.
 
@@ -300,10 +313,12 @@ metadata.foobar;     // any (arbitrary meta tag found on page; mostly returns as
 const strict = await urlMetadata(url) as urlMetadata.KnownFieldsStrict;
 ```
 
-Using the `omitEmpty` option? Empty fields are dropped from the result, so the "always present" guarantee no longer holds — cast to `Partial` instead:
+When you pass `fields` or `omitEmpty: true` options, the return type narrows to `Partial<urlMetadata.KnownFields>` automatically. Known fields become optional (any of them may be filtered out), and no cast is needed:
 
 ```ts
-const metadata = await urlMetadata(url, { omitEmpty: true }) as Partial<urlMetadata.KnownFields>;
+const partial = await urlMetadata(url, { fields: ['og', 'network'] });
+partial['og:title'];        // string | undefined
+partial.responseStatusCode; // number | undefined
 ```
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Optional mode 
 - img tags
 - the full response body as a string of html (optional)
 
-### Performance Tuning & Token-Efficiency
+### Performance & Token-Efficiency
 - Use `fields` option to request only what you need
 - Shrinks the response size *and* skips the extra extraction work
 - Use `omitEmpty: true` option to drop empty fields
@@ -88,8 +88,8 @@ const options = {
   },
 
   // Route the fetch through a proxy/ unblocking service.
-  // In proxy mode, other fetch-related options will be
-  // silently ignored. Details in  "Proxy Mode" section below.
+  // In proxy mode, other fetch-related options apply to the proxy
+  // fetch, not the target URL. See  "Proxy Mode" section below.
   // Presence of proxyUrl alone triggers proxy mode.
   proxyUrl: undefined,
   // Optional vendor-specific query params passed thru as-is,
@@ -215,7 +215,7 @@ console.log(metadata);
 ### Proxy mode for blocked web pages (403 errors)
 This package is vendor-neutral. Any proxy (unblocking) service works via `proxyUrl` + `proxyParams`. Two vendors are documented below, affiliate links support the author. Want another added? Ask in the [Discord support channel](https://discord.gg/BqVBeeGsc5).
 
-`proxyUrl` triggers proxy mode. Proxy calls route through a third party doing its own upstream fetch, which takes longer than a direct fetch — so `options.timeout` defaults to 60 seconds in instead of the usual 10, or you can customize.
+`proxyUrl` triggers proxy mode. Proxy calls route through a third party doing its own upstream fetch, which takes longer than a direct fetch — so `options.timeout` defaults to 60 seconds instead of the usual 10, or you can customize.
 
 `proxyParams` is a flat passthru, sent verbatim as query params exactly as named in your vendor's docs - no allowlist, no translation on our side. Some vendors authenticate via a header instead of a query param (ex: an `x-api-key` header) — for those, pass it in `requestHeaders` instead and skip `proxyParams` entirely if the vendor needs no other params.
 
@@ -303,6 +303,8 @@ probe.performance;        // { ttfbMs, redirectTimeMs, ... }
 ```
 
 Since the body is never read, `performance.responseTimeMs` is `undefined` in this mode; there's no body-read to measure.
+
+**Note:** `fields: ['network']` (only) and `proxyUrl` throw an error when used together, since no fetch happens in `network` mode.
 
 ## Returns
 Returns a promise resolved with a JSON object. Note that the returned `url` field will be the last hop in the request chain if there are redirects.

--- a/README.md
+++ b/README.md
@@ -267,13 +267,15 @@ const metadata = await urlMetadata('https://hardto.get', {
 
 ### Performance Tuning
 
-By default every field is extracted and returned. Pass the `fields` option an array to narrow that down. The response only includes what you list, and the extractors for everything else never run.
+This is a powerful lever for optimizing the amount of processing that takes place for each target URL. By default every field is extracted and returned. Pass the `fields` option an array to narrow that down. The response only includes what you list, and the extractors for everything else never run.
 
 `fields` accepts atomic field names (any key from `lib/metadata-fields.js`) plus these named groups:
 - **`network`** — transport data only (status, headers, redirects, timing); see below, it's special
 - **`meta`** — every meta tag, including page-specific ones not on the built-in list
 - **`og`** — all [Open Graph](http://ogp.me/) (`og:`) tags
 - **`twitter`** — all [Twitter Card](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) (`twitter:`) tags
+
+Selecting a group keeps its empty fields so the shape stays predictable; add `omitEmpty: true` to drop them. An unknown token or an empty `fields: []` throws.
 
 For a single page-specific meta tag, use the `meta:<name>` syntax — the part after `meta:` is the exact tag name, colons and all (`meta:og:url` is valid):
 
@@ -282,8 +284,6 @@ const metadata = await urlMetadata(url, {
   fields: ['title', 'og', 'meta:dc.creator']
 });
 ```
-
-Selecting a group keeps its empty fields so the shape stays predictable; add `omitEmpty: true` to drop them. An unknown token or an empty `fields: []` throws.
 
 #### The `network` group: a fast, universal probe
 
@@ -304,7 +304,7 @@ probe.performance;        // { ttfbMs, redirectTimeMs, ... }
 
 Since the body is never read, `performance.responseTimeMs` is `undefined` in this mode; there's no body-read to measure.
 
-**Note:** `fields: ['network']` (only) and `proxyUrl` throw an error when used together, since no fetch happens in `network` mode.
+**Note:** `fields: ['network']` (only) and `proxyUrl` throw an error when used together, since no body-read happens in `network`-only mode, and the proxy executes the fetch on your target URL and returns the result in the body.
 
 ## Returns
 Returns a promise resolved with a JSON object. Note that the returned `url` field will be the last hop in the request chain if there are redirects.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fetch a URL and scrape its metadata using Node.js or the browser. Optional mode 
 
 ---
 <div>
-  👉 <i><strong>Looking for a quick hosted solution?</i> <a href="https://minifetch.com">Minifetch</a></strong> is an extraction & SEO toolkit built on top of this package by the same author/ maintainer. Get started free:
+  👉 <i><strong>Looking for a quick hosted solution?</i> <a href="https://minifetch.com">Minifetch</a></strong> is a web page extraction & SEO toolkit built on top of this package by the same author. Get started free:
   <a href="https://www.npmjs.com/package/minifetch-api">npm install minifetch-api</a>
 </div>
 
@@ -267,15 +267,15 @@ const metadata = await urlMetadata('https://hardto.get', {
 
 ### Performance Tuning
 
-This is a powerful lever for optimizing the amount of processing that takes place for each target URL. By default every field is extracted and returned. Pass the `fields` option an array to narrow that down. The response only includes what you list, and the extractors for everything else never run.
+This package has powerful levers for optimizing the amount of processing that takes place for each target URL *and* for reducing response sizes. By default every metadata field is extracted and returned. Pass the `fields` option an array to narrow that down. The response only includes what you list, and the extractors for everything else never run.
 
-`fields` accepts atomic field names (any key from `lib/metadata-fields.js`) plus these named groups:
+`fields` accepts atomic field names ([any key from `lib/metadata-fields.js`](https://github.com/laurengarcia/url-metadata/blob/master/lib/metadata-fields.js)) plus these named groups:
 - **`network`** — transport data only (status, headers, redirects, timing); see below, it's special
 - **`meta`** — every meta tag, including page-specific ones not on the built-in list
 - **`og`** — all [Open Graph](http://ogp.me/) (`og:`) tags
 - **`twitter`** — all [Twitter Card](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) (`twitter:`) tags
 
-Selecting a group keeps its empty fields so the shape stays predictable; add `omitEmpty: true` to drop them. An unknown token or an empty `fields: []` throws.
+Selecting a group keeps its empty fields so the shape stays predictable; add `omitEmpty: true` to drop empty fields entirely for further streamlining. An unknown token or an empty `fields: []` throws.
 
 For a single page-specific meta tag, use the `meta:<name>` syntax — the part after `meta:` is the exact tag name, colons and all (`meta:og:url` is valid):
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,13 @@ const options = {
   descriptionLength: 750,
 
   // Include raw response body as string
-  includeResponseBody: false
+  includeResponseBody: false,
+
+  // Drop empty fields (undefined, null, '', [], {}) from the returned
+  // object for a smaller, more token-efficient response. Shallow: only
+  // top-level fields are removed. If you cast in Typescript, use:
+  // `Partial<urlMetadata.KnownFields>` (see below).
+  omitEmpty: false
 };
 
 // Options usage:
@@ -292,6 +298,12 @@ metadata.foobar;     // any (arbitrary meta tag found on page; mostly returns as
 // Catches typos at compile time, but arbitrary page-specific
 // meta tags (incl. `citation_*`) are compile errors:
 const strict = await urlMetadata(url) as urlMetadata.KnownFieldsStrict;
+```
+
+Using the `omitEmpty` option? Empty fields are dropped from the result, so the "always present" guarantee no longer holds — cast to `Partial` instead:
+
+```ts
+const metadata = await urlMetadata(url, { omitEmpty: true }) as Partial<urlMetadata.KnownFields>;
 ```
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ const options = {
   // Also accepts specific meta tags with the "meta:<name>" syntax, ex:
   // ['meta:description'] or ['meta:og:url']
   // See "Performance Tuning" section below.
-  fields: undefined
+  fields: undefined,
 
   // Drop empty fields (undefined, null, '', [], {}) from the returned
   // object. Shallow: only top-level fields are removed.
-  omitEmpty: false
+  omitEmpty: false,
 
   // (Node.js v18.17+ only)
   // To prevent SSRF attacks, the default option blocks fetch
@@ -165,7 +165,7 @@ const options = {
   descriptionLength: 750,
 
   // Include raw response body as string
-  includeResponseBody: false,
+  includeResponseBody: false
 };
 
 // Options usage:
@@ -266,6 +266,43 @@ const metadata = await urlMetadata('https://hardto.get', {
 ```
 
 ### Performance Tuning
+
+By default every field is extracted and returned. Pass the `fields` option an array to narrow that down. The response only includes what you list, and the extractors for everything else never run.
+
+`fields` accepts atomic field names (any key from `lib/metadata-fields.js`) plus these named groups:
+- **`network`** — transport data only (status, headers, redirects, timing); see below, it's special
+- **`meta`** — every meta tag, including page-specific ones not on the built-in list
+- **`og`** — all [Open Graph](http://ogp.me/) (`og:`) tags
+- **`twitter`** — all [Twitter Card](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) (`twitter:`) tags
+
+For a single page-specific meta tag, use the `meta:<name>` syntax — the part after `meta:` is the exact tag name, colons and all (`meta:og:url` is valid):
+
+```js
+const metadata = await urlMetadata(url, {
+  fields: ['title', 'og', 'meta:dc.creator']
+});
+```
+
+Selecting a group keeps its empty fields so the shape stays predictable; add `omitEmpty: true` to drop them. An unknown token or an empty `fields: []` throws.
+
+#### The `network` group: a fast, universal probe
+
+`network` resolves as soon as the response **headers** arrive and **never downloads the response body**. A cheap way to check status, redirect chain, and timing without fetching the whole page.
+
+Because it doesn't read the body, **`network` works on any URL regardless of content type** — HTML, PDFs, images, JSON, binaries where a normal fetch would otherwise throw `unsupported content type`:
+
+```js
+// Probe any URL — no body downloaded, any content type works:
+const probe = await urlMetadata('https://pdfobject.com/pdf/sample.pdf', {
+  fields: ['network']
+});
+probe.responseStatusCode; // 200
+probe.responseHeaders;    // { 'content-type': 'application/pdf', ... }
+probe.redirects;          // { count, chain }
+probe.performance;        // { ttfbMs, redirectTimeMs, ... }
+```
+
+Since the body is never read, `performance.responseTimeMs` is `undefined` in this mode; there's no body-read to measure.
 
 ## Returns
 Returns a promise resolved with a JSON object. Note that the returned `url` field will be the last hop in the request chain if there are redirects.

--- a/example-javascript-require/package.json
+++ b/example-javascript-require/package.json
@@ -7,6 +7,6 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "url-metadata": "^5.7.5-beta.0"
+    "url-metadata": "file:../url-metadata-5.9.0.tgz"
   }
 }

--- a/example-nextjs/package.json
+++ b/example-nextjs/package.json
@@ -6,7 +6,7 @@
     "next": "^15.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "url-metadata": "file:../url-metadata-5.8.1.tgz"
+    "url-metadata": "file:../url-metadata-5.9.0.tgz"
   },
   "scripts": {
     "dev": "next dev",

--- a/example-typescript/index.ts
+++ b/example-typescript/index.ts
@@ -73,3 +73,34 @@ async function resultStaysPermissiveCanary (url: string) {
 
   return [s, mock, title, favs, hops, req, extra];
 }
+
+// --- COMPILE-ONLY canary: sparse return-type overloads. Never called. ---
+// Locks the guarantee that `fields` (any selection) and `omitEmpty: true`
+// narrow the result to Partial<KnownFields> (known fields optional & real-
+// typed), while `omitEmpty: false` and no selection stay the loose `Result`.
+// Relies on strictNullChecks (tsconfig `strict: true`). DO NOT CALL.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function sparseReturnTypeCanary (url: string) {
+  // `fields` present -> Partial<KnownFields>
+  const picked = await urlMetadata(url, { fields: ['title'] });
+  const okPicked: Partial<urlMetadata.KnownFields> = picked; // assignable
+  // @ts-expect-error Partial (optional fields) is NOT assignable to the all-present Strict shape
+  const strictPicked: urlMetadata.KnownFieldsStrict = picked;
+
+  // `omitEmpty: true` -> Partial<KnownFields>
+  const pruned = await urlMetadata(url, { omitEmpty: true });
+  const okPruned: Partial<urlMetadata.KnownFields> = pruned;
+  // @ts-expect-error Partial is NOT assignable to Strict
+  const strictPruned: urlMetadata.KnownFieldsStrict = pruned;
+
+  // `omitEmpty: false` -> loose `Result` (known keys resolve to `any`)
+  const full = await urlMetadata(url, { omitEmpty: false });
+  const okFull: urlMetadata.Result = full;
+  full.responseStatusCode.whatever; // any: compiles; would error under Partial
+
+  // no `fields`/`omitEmpty` -> `Result`
+  const plain = await urlMetadata(url, { descriptionLength: 500 });
+  const okPlain: urlMetadata.Result = plain;
+
+  return [okPicked, strictPicked, okPruned, strictPruned, okFull, okPlain];
+}

--- a/example-typescript/package.json
+++ b/example-typescript/package.json
@@ -8,7 +8,7 @@
     "start": "http-server dist"
   },
   "dependencies": {
-    "url-metadata": "file:../url-metadata-5.8.1.tgz"
+    "url-metadata": "file:../url-metadata-5.9.0.tgz"
   },
   "devDependencies": {
     "assert": "^2.1.0",

--- a/example-vite/package.json
+++ b/example-vite/package.json
@@ -13,6 +13,6 @@
     "vite": "^6.2.0"
   },
   "dependencies": {
-    "url-metadata": "file:../url-metadata-5.8.1.tgz"
+    "url-metadata": "file:../url-metadata-5.9.0.tgz"
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare namespace urlMetadata {
     descriptionLength?: number;
     includeResponseBody?: boolean;
     omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; cast result to Partial<KnownFields>
+    fields?: string[]; // sparse fieldset: atomic keys, group names ('network'|'og'|'twitter'|'meta'), and/or 'meta:<name>' for page-specific tags; undefined returns full result
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,27 @@
 export = urlMetadata
 
+// Definitions are loose by default so arbitrary scraped meta tags
+// never fight the compiler: default results are `Result` (≈ any).
+// Opt into `KnownFields` / `KnownFieldsStrict` for structure;
+// `fields` or `omitEmpty: true` options auto-narrow to Partial.
+// Types only — nothing here changes runtime behavior.
+
+// Definition overloads resolve top-to-bottom.
+// A sparse selection (`fields`, or `omitEmpty: true` options) drops
+// the default "always present" guarantee, so the Result is typed:
+// `Partial<KnownFields>`
+declare function urlMetadata(
+  url: string | null,
+  options: urlMetadata.Options & { fields: string[] },
+): Promise<Partial<urlMetadata.KnownFields>>
+
+declare function urlMetadata(
+  url: string | null,
+  options: urlMetadata.Options & { omitEmpty: true },
+): Promise<Partial<urlMetadata.KnownFields>>
+
+// The default (fallback — must stay last): all returned fields are present,
+// whether empty or not. `Result` is intentionally loose, by design. See below.
 declare function urlMetadata(
   url: string | null,
   options?: urlMetadata.Options,
@@ -23,7 +45,7 @@ declare namespace urlMetadata {
     mode?: string;
     descriptionLength?: number;
     includeResponseBody?: boolean;
-    omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; cast result to Partial<KnownFields>
+    omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; when true, result is typed Partial<KnownFields>
     fields?: string[]; // sparse fieldset: atomic keys, group names ('network'|'og'|'twitter'|'meta'), and/or 'meta:<name>' for page-specific tags; undefined returns full result
   }
 
@@ -52,8 +74,8 @@ declare namespace urlMetadata {
    * page are appended as new fields, as strings — except tags starting
    * with `citation_`, which are string[] (per Google Scholar spec, see README).
    *
-   * When `omitEmpty` option is true, empty fields are dropped, so cast to
-   * `Partial<KnownFields>` instead — presence guarantees no longer hold.
+   * With `fields` or `omitEmpty: true`, presence guarantees no longer hold;
+   * the function returns `Partial<KnownFields>` automatically (no cast needed).
    */
   interface KnownFields extends KnownFieldsStrict {
     [metaTagName: string]: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,8 @@ declare namespace urlMetadata {
     proxyUrl?: string; // proxy/unblocking service endpoint (ex: https://api.scraperapi.com/); presence of this triggers proxy mode
     proxyParams?: ProxyParams;
     parseResponseObject?: globalThis.Response | import('node-fetch').Response;
+    fields?: string[]; // sparse fieldset: atomic keys, group names ('network'|'og'|'twitter'|'meta'), and/or 'meta:<name>' for page-specific tags; undefined returns full result
+    omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; when true, result is typed Partial<KnownFields>
     requestFilteringAgentOptions?: import('request-filtering-agent').RequestFilteringAgentOptions;
     agent?: any; // Suggest: Node.js http.Agent | https.Agent
     maxRedirects?: number;
@@ -45,8 +47,6 @@ declare namespace urlMetadata {
     mode?: string;
     descriptionLength?: number;
     includeResponseBody?: boolean;
-    omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; when true, result is typed Partial<KnownFields>
-    fields?: string[]; // sparse fieldset: atomic keys, group names ('network'|'og'|'twitter'|'meta'), and/or 'meta:<name>' for page-specific tags; undefined returns full result
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare namespace urlMetadata {
     mode?: string;
     descriptionLength?: number;
     includeResponseBody?: boolean;
+    omitEmpty?: boolean; // drop top-level empty fields (undefined, null, '', [], {}) for token efficiency; cast result to Partial<KnownFields>
   }
 
   /**
@@ -49,6 +50,9 @@ declare namespace urlMetadata {
    * Known fields are fully typed; any additional meta tags found on the
    * page are appended as new fields, as strings — except tags starting
    * with `citation_`, which are string[] (per Google Scholar spec, see README).
+   *
+   * When `omitEmpty` option is true, empty fields are dropped, so cast to
+   * `Partial<KnownFields>` instead — presence guarantees no longer hold.
    */
   interface KnownFields extends KnownFieldsStrict {
     [metaTagName: string]: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,9 +70,9 @@ declare namespace urlMetadata {
     responseStatusCode: number;
     responseHeaders: Record<string, string>; // whitelisted set, see lib/extract-headers.js
     performance: {
+      redirectTimeMs: number | undefined; // only set when redirects occurred
       ttfbMs: number | undefined; // cumulative: first request start -> final hop's headers arriving
       responseTimeMs: number | undefined; // cumulative: first request start -> body read complete
-      redirectTimeMs: number | undefined; // only set when redirects occurred
     };
     canonical: string; // first <link rel="canonical"> found, empty string if none
     canonicalUrls: string[]; // raw href of every canonical tag, in document order

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -129,7 +129,7 @@ MetadataFields.prototype.clean = function () {
   Object.keys(this.fields).forEach(function (key) {
     self.fields[key] = clean(key, self.fields[key], self.options)
   })
-  // `omitEmpty` opt-in: drop empty fields for token efficiency. Shallow &
+  // `omitEmpty` option: drop empty fields for token efficiency. Shallow &
   // insertion-order preserving. Breaks the always-present guarantee, so the
   // result types as Partial<KnownFields> (see index.d.ts).
   if (this.options.omitEmpty) {

--- a/lib/metadata-fields.js
+++ b/lib/metadata-fields.js
@@ -1,4 +1,5 @@
 const clean = require('./clean')
+const utils = require('./utils')
 
 module.exports = MetadataFields
 
@@ -128,5 +129,15 @@ MetadataFields.prototype.clean = function () {
   Object.keys(this.fields).forEach(function (key) {
     self.fields[key] = clean(key, self.fields[key], self.options)
   })
+  // `omitEmpty` opt-in: drop empty fields for token efficiency. Shallow &
+  // insertion-order preserving. Breaks the always-present guarantee, so the
+  // result types as Partial<KnownFields> (see index.d.ts).
+  if (this.options.omitEmpty) {
+    const pruned = {}
+    Object.keys(this.fields).forEach(function (key) {
+      if (!utils.isEmpty(self.fields[key])) pruned[key] = self.fields[key]
+    })
+    this.fields = pruned
+  }
   return this.fields
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,6 +8,7 @@ const extractJsonLd = require('./extract-json-ld')
 const extractHeadings = require('./extract-headings')
 const extractImgTags = require('./extract-img-tags')
 const extractHeaders = require('./extract-headers')
+const utils = require('./utils')
 
 module.exports = function (
   requestUrl,
@@ -63,4 +64,55 @@ module.exports = function (
 
   // clean up and return all metadata fields
   return metadata.clean()
+}
+
+/**
+ * Assembles a header-only (`network`) result: transport fields available
+ * from the response headers, without reading or parsing the body. Used when
+ * `fields` selects only header-available data — skips cheerio & all
+ * extractors. Filters to `requestedKeys` (plus `responseBody` when
+ * `includeResponseBody` is set) and honors `omitEmpty`.
+ *
+ * @param {string} requestUrl
+ * @param {object} redirects
+ * @param {object} perf - performance timing (responseTimeMs stays undefined; body unread)
+ * @param {string} destinationUrl - final url in the request chain
+ * @param {number} responseStatusCode
+ * @param {*} responseHeaders - Headers-like object (whitelisted by extractHeaders)
+ * @param {Set<string>} requestedKeys - the network field keys to return
+ * @param {string|undefined} body - raw body, only when includeResponseBody
+ * @param {object} options
+ * @returns {object} filtered header-only metadata
+ */
+module.exports.headerOnly = function (
+  requestUrl,
+  redirects,
+  perf,
+  destinationUrl,
+  responseStatusCode,
+  responseHeaders,
+  requestedKeys,
+  body,
+  options
+) {
+  const raw = {
+    requestUrl,
+    redirects,
+    url: destinationUrl,
+    responseStatusCode,
+    responseHeaders: extractHeaders(responseHeaders),
+    performance: perf
+  }
+  if (options.includeResponseBody) raw.responseBody = body
+
+  const keys = new Set(requestedKeys)
+  if (options.includeResponseBody) keys.add('responseBody')
+
+  const result = {}
+  Object.keys(raw).forEach(function (key) {
+    if (!keys.has(key)) return
+    if (options.omitEmpty && utils.isEmpty(raw[key])) return
+    result[key] = raw[key]
+  })
+  return result
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,6 +9,7 @@ const extractHeadings = require('./extract-headings')
 const extractImgTags = require('./extract-img-tags')
 const extractHeaders = require('./extract-headers')
 const utils = require('./utils')
+const { selectFields } = require('./resolve-fields')
 
 module.exports = function (
   requestUrl,
@@ -62,8 +63,11 @@ module.exports = function (
     metadata.set({ responseBody: body })
   }
 
-  // clean up and return all metadata fields
-  return metadata.clean()
+  // clean up all metadata fields
+  const cleaned = metadata.clean()
+
+  // filter to the selected `fields`, if any (full output otherwise)
+  return options.fields ? selectFields(cleaned, options.fields) : cleaned
 }
 
 /**

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,7 +9,7 @@ const extractHeadings = require('./extract-headings')
 const extractImgTags = require('./extract-img-tags')
 const extractHeaders = require('./extract-headers')
 const utils = require('./utils')
-const { selectFields } = require('./resolve-fields')
+const { selectFields, selectionIncludes, needsMetaTags } = require('./resolve-fields')
 
 module.exports = function (
   requestUrl,
@@ -22,34 +22,46 @@ module.exports = function (
   options
 ) {
   const $ = cheerio.load(body)
-  const title = $('head title').text()
-  const lang = $('html').attr('lang') || ''
-  const scrapedHreflang = extractHreflang($)
-  const scrapedCanonical = extractCanonical($)
-  const scrapedMetaTags = extractMetaTags($)
-  const scrapedJsonLd = extractJsonLd($)
-  const scrapedFavicons = extractFavicons($)
-  const headings = extractHeadings($)
-  const imgTags = extractImgTags($)
+
+  // Extractor gating to optimize/ reduce processing.
+  // With `fields` option set, only run an extractor whose output is selected;
+  // with no `fields`, `wants` is always true so every extractor runs
+  // (full output, unchanged). Skipped extractors return their seed-default
+  // empties, which selectFields drops anyway — so output is identical, just cheaper.
+  const fields = options.fields
+  const wants = (name) => !fields || selectionIncludes(fields, name)
+  const wantsMeta = !fields || needsMetaTags(fields)
+
+  const title = wants('title') ? $('head title').text() : ''
+  const lang = wants('lang') ? ($('html').attr('lang') || '') : ''
+  const scrapedHreflang = wants('hreflang') ? extractHreflang($) : []
+  const scrapedCanonical = (wants('canonical') || wants('canonicalUrls'))
+    ? extractCanonical($)
+    : { canonical: '', canonicalUrls: [] }
+  const scrapedMetaTags = wantsMeta ? extractMetaTags($) : {}
+  const scrapedJsonLd = wants('jsonld') ? extractJsonLd($) : []
+  const scrapedFavicons = wants('favicons') ? extractFavicons($) : []
+  const headings = wants('headings') ? extractHeadings($) : []
+  const imgTags = wants('imgTags') ? extractImgTags($) : []
 
   const metadata = new MetadataFields(options)
     // requestUrl echoes the url param verbatim, incl falsy values in
     // parseResponseObject mode ('', undefined, null). Deliberate.
     .set({ requestUrl })
     .set({ redirects })
-    .set({ performance: perf })
     .set({ url: destinationUrl })
+    .set({ responseStatusCode })
+    .set({ responseHeaders: extractHeaders(responseHeaders) })
+    .set({ performance: perf })
+    .set({ title })
     .set(scrapedMetaTags)
     .set({ hreflang: scrapedHreflang })
     .set({ canonicalUrls: scrapedCanonical.canonicalUrls })
     .set({ favicons: scrapedFavicons })
-    .set({ title })
     .set({ lang })
     .set({ jsonld: scrapedJsonLd })
     .set({ headings })
     .set({ imgTags })
-    .set({ responseStatusCode })
-    .set({ responseHeaders: extractHeaders(responseHeaders) })
 
   // canonical: prefer an explicit metadata-fields/options value if one was
   // already set; otherwise fall back to the first <link rel="canonical">

--- a/lib/resolve-fields.js
+++ b/lib/resolve-fields.js
@@ -166,6 +166,41 @@ function selectFields (metadata, fields) {
   return result
 }
 
+/**
+ * Static (pre-parse) test for whether a selection would include field `name`.
+ * Mirrors selectFields' resolution but on tokens alone, so extractors can be
+ * gated before the metadata object exists.
+ * @param {string[]} fields - validated selection tokens
+ * @param {string} name - a field key
+ * @returns {boolean}
+ */
+function selectionIncludes (fields, name) {
+  return fields.some(function (token) {
+    if (token === name) return true
+    if (token === 'og') return name.startsWith('og:')
+    if (token === 'twitter') return name.startsWith('twitter:')
+    if (token === 'network') return networkFieldSet.has(name)
+    if (token === 'meta') return !NON_META_KEYS.has(name)
+    if (token.startsWith('meta:')) return token.slice(5) === name
+    return false
+  })
+}
+
+/**
+ * True when a selection could include any meta-tag-sourced field, so the
+ * single-pass meta-tag extractor must run. Covers the `meta`/`og`/`twitter`
+ * groups, `meta:<name>` selectors, and atomic meta keys.
+ * @param {string[]} fields
+ * @returns {boolean}
+ */
+function needsMetaTags (fields) {
+  return fields.some(function (token) {
+    if (token === 'meta' || token === 'og' || token === 'twitter') return true
+    if (token.startsWith('meta:')) return true
+    return atomicKeys.has(token) && !NON_META_KEYS.has(token)
+  })
+}
+
 module.exports = resolveFields
 module.exports.NETWORK_FIELDS = NETWORK_FIELDS
 module.exports.NON_META_KEYS = NON_META_KEYS
@@ -173,3 +208,5 @@ module.exports.isHeaderOnly = isHeaderOnly
 module.exports.expandHeaderSelection = expandHeaderSelection
 module.exports.hasNetworkGroup = hasNetworkGroup
 module.exports.selectFields = selectFields
+module.exports.selectionIncludes = selectionIncludes
+module.exports.needsMetaTags = needsMetaTags

--- a/lib/resolve-fields.js
+++ b/lib/resolve-fields.js
@@ -65,4 +65,55 @@ function resolveFields (fields) {
   return fields
 }
 
+// The `network` group: transport fields available once response headers
+// arrive, without reading the body. Single source of truth for both the
+// group's membership and the body-skip optimization in main.js.
+const NETWORK_FIELDS = ['requestUrl', 'redirects', 'url', 'responseStatusCode', 'responseHeaders', 'performance']
+const networkFieldSet = new Set(NETWORK_FIELDS)
+
+/**
+ * True when every requested token can be satisfied from response headers
+ * alone (the `network` group or any subset of its atomic fields), so the
+ * body read can be skipped. False for null/undefined or any selection that
+ * includes a body-dependent field.
+ * @param {string[]|null|undefined} fields
+ * @returns {boolean}
+ */
+function isHeaderOnly (fields) {
+  if (!fields) return false
+  return fields.every(function (token) {
+    return token === 'network' || networkFieldSet.has(token)
+  })
+}
+
+/**
+ * Expands a header-only selection to the concrete set of requested network
+ * field keys (`network` -> all six; atomic network fields -> themselves).
+ * Only meaningful when `isHeaderOnly(fields)` is true.
+ * @param {string[]} fields
+ * @returns {Set<string>}
+ */
+function expandHeaderSelection (fields) {
+  const set = new Set()
+  fields.forEach(function (token) {
+    if (token === 'network') NETWORK_FIELDS.forEach(function (f) { set.add(f) })
+    else set.add(token)
+  })
+  return set
+}
+
+/**
+ * True when the `network` group token is present. Used to guard
+ * `parseResponseObject` mode, where the group is not meaningful.
+ * @param {string[]|null|undefined} fields
+ * @returns {boolean}
+ */
+function hasNetworkGroup (fields) {
+  return !!fields && fields.includes('network')
+}
+
 module.exports = resolveFields
+module.exports.NETWORK_FIELDS = NETWORK_FIELDS
+module.exports.isHeaderOnly = isHeaderOnly
+module.exports.expandHeaderSelection = expandHeaderSelection
+module.exports.hasNetworkGroup = hasNetworkGroup

--- a/lib/resolve-fields.js
+++ b/lib/resolve-fields.js
@@ -1,0 +1,68 @@
+const MetadataFields = require('./metadata-fields')
+
+// Valid atomic field keys, derived from the seed object (single source of
+// truth in metadata-fields.js) so this list can never drift from what the
+// parser actually produces.
+const atomicKeys = new Set(Object.keys(new MetadataFields({}).fields))
+
+// Legal named-group tokens. Their expansion to atomic keys is handled in a
+// later step; validation only needs to know these names are legal.
+const groupNames = new Set(['network', 'og', 'twitter', 'meta'])
+
+/**
+ * Validates `options.fields` eagerly (before any network round-trip).
+ *
+ * Bare tokens are strict: each must be a known atomic field key from
+ * /lib/metadata-fields.js or group name, else it throws.
+ *
+ * Page-specific meta tags that aren't on the whitelist are reachable via
+ * the `meta:<name>` escape hatch — the remainder after the `meta:` prefix
+ * is the literal tag name (never split on `:`, so names with colons like
+ * `al:ios:url` work; known suffixes like `meta:og:title` are allowed and
+ * redundant). The arbitrary name itself can't be validated pre-fetch, so
+ * a `meta:`-prefixed token always passes shape validation.
+ *
+ * @param {string[]|undefined} fields - array of atomic field keys, group
+ *   names, and/or `meta:<name>` selectors; undefined for the default
+ *   (full, unfiltered) result.
+ * @returns {string[]|null} the validated tokens, or null when `fields` is
+ *   undefined (signal: no filtering, return the full default result).
+ * @throws {Error} on a non-array, an empty array, a non-string token, a
+ *   `meta:` selector with no name, or an unknown bare token.
+ */
+function resolveFields (fields) {
+  if (fields === undefined) return null
+
+  if (!Array.isArray(fields)) {
+    throw new Error('`fields` option must be an array of strings')
+  }
+  if (fields.length === 0) {
+    throw new Error('`fields` option cannot be an empty array')
+  }
+
+  fields.forEach(function (token) {
+    if (typeof token !== 'string') {
+      throw new Error('`fields` tokens must be strings')
+    }
+
+    // `meta:<name>` escape hatch for page-specific meta tags not on the
+    // whitelist. Strip the 5-char `meta:` prefix; the whole remainder is the
+    // literal tag name (no `:` split). The name can't be validated pre-fetch,
+    // so any non-empty suffix passes.
+    if (token.startsWith('meta:')) {
+      if (token.slice(5) === '') {
+        throw new Error('`fields` token `meta:` is missing a tag name')
+      }
+      return
+    }
+
+    // Bare tokens are strict: known atomic key or group name only.
+    if (!atomicKeys.has(token) && !groupNames.has(token)) {
+      throw new Error(`unknown \`fields\` token: '${token}' (for a page-specific meta tag, prefix with 'meta:')`)
+    }
+  })
+
+  return fields
+}
+
+module.exports = resolveFields

--- a/lib/resolve-fields.js
+++ b/lib/resolve-fields.js
@@ -5,7 +5,7 @@ const MetadataFields = require('./metadata-fields')
 // parser actually produces.
 const atomicKeys = new Set(Object.keys(new MetadataFields({}).fields))
 
-// Legal named-group tokens. Their expansion to atomic keys is handled in a
+// Named-group tokens. Expansion to atomic keys is handled in a
 // later step; validation only needs to know these names are legal.
 const groupNames = new Set(['network', 'og', 'twitter', 'meta'])
 
@@ -112,8 +112,64 @@ function hasNetworkGroup (fields) {
   return !!fields && fields.includes('network')
 }
 
+// Structural (non-meta-tag) seed keys. Everything else in the result is
+// meta-tag-sourced (whitelisted or arbitrary), so the `meta` group is defined
+// as its complement. A denylist (vs a meta allowlist) is smaller, more
+// stable, and drift-friendly: newly-whitelisted meta fields are `meta` for
+// free; only new *structural* fields need to be added here (see drift test).
+// Note: `charset` is intentionally NOT here — `<meta charset>` is a meta tag.
+const NON_META_KEYS = new Set([
+  'requestUrl', 'redirects', 'url', 'responseStatusCode', 'responseHeaders',
+  'performance', 'canonical', 'canonicalUrls', 'lang', 'hreflang', 'title',
+  'favicons', 'jsonld', 'headings', 'imgTags', 'responseBody'
+])
+
+/**
+ * Filters a fully-parsed metadata object down to the selected `fields`.
+ * Groups expand against the object's own keys, so empty whitelisted keys are
+ * kept (selection is orthogonal to `omitEmpty`, which is the only knob that
+ * drops empties). Only keys actually present in `metadata` are returned, so a
+ * `meta:<name>` for a tag the page lacks is simply absent.
+ *
+ * - `network`        -> the six transport fields
+ * - `og` / `twitter` -> keys with that prefix
+ * - `meta`           -> every non-structural key (whitelisted + arbitrary tags)
+ * - `meta:<name>`    -> the literal key `<name>`
+ * - anything else    -> an atomic key
+ *
+ * @param {object} metadata - the cleaned, full result object
+ * @param {string[]} fields - validated selection tokens
+ * @returns {object} a new object with only the selected keys (insertion order preserved)
+ */
+function selectFields (metadata, fields) {
+  const metadataKeys = Object.keys(metadata)
+  const keep = new Set()
+
+  fields.forEach(function (token) {
+    if (token === 'network') {
+      NETWORK_FIELDS.forEach(function (k) { keep.add(k) })
+    } else if (token === 'og') {
+      metadataKeys.forEach(function (k) { if (k.startsWith('og:')) keep.add(k) })
+    } else if (token === 'twitter') {
+      metadataKeys.forEach(function (k) { if (k.startsWith('twitter:')) keep.add(k) })
+    } else if (token === 'meta') {
+      metadataKeys.forEach(function (k) { if (!NON_META_KEYS.has(k)) keep.add(k) })
+    } else if (token.startsWith('meta:')) {
+      keep.add(token.slice(5))
+    } else {
+      keep.add(token) // atomic key
+    }
+  })
+
+  const result = {}
+  metadataKeys.forEach(function (k) { if (keep.has(k)) result[k] = metadata[k] })
+  return result
+}
+
 module.exports = resolveFields
 module.exports.NETWORK_FIELDS = NETWORK_FIELDS
+module.exports.NON_META_KEYS = NON_META_KEYS
 module.exports.isHeaderOnly = isHeaderOnly
 module.exports.expandHeaderSelection = expandHeaderSelection
 module.exports.hasNetworkGroup = hasNetworkGroup
+module.exports.selectFields = selectFields

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,6 +36,19 @@ module.exports = {
       src = 'https:' + src
     }
     return src
+  },
+
+  /**
+   * True for values `omitEmpty` should drop: `undefined`, `null`, empty
+   * string, empty array [], empty object {}. Shallow — top-level fields only, no
+   * recursion into nested objects (ex: `performance`, `redirects`), which are
+   * dropped only when they have zero own keys.
+   */
+  isEmpty: function (value) {
+    if (value === undefined || value === null || value === '') return true
+    if (Array.isArray(value)) return value.length === 0
+    if (typeof value === 'object') return Object.keys(value).length === 0
+    return false
   }
 
 }

--- a/main.js
+++ b/main.js
@@ -36,7 +36,8 @@ module.exports = function (url, options, _fetch, useAgent) {
       cache: 'no-cache', // Browser only
       mode: 'cors', // Browser only
       descriptionLength: 750,
-      includeResponseBody: false
+      includeResponseBody: false,
+      omitEmpty: false // drop empty fields (undefined, null, '', [], {}) from result for token efficiency
     },
     // user options override defaults
     options

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const extractCharset = require('./lib/extract-charset')
 const parse = require('./lib/parse')
 const createHttpError = require('./lib/http-error')
 const resolveFields = require('./lib/resolve-fields')
+const { isHeaderOnly, expandHeaderSelection, hasNetworkGroup } = resolveFields
 
 // Monotonic clock when available (browsers + Node 16+), else wall clock fallback.
 // Every perf value is a delta from the same source, so the two never mix.
@@ -12,6 +13,17 @@ const now = (typeof performance !== 'undefined' && performance.now)
 // Credential-bearing headers dropped when a redirect hop changes host,
 // mirroring browsers & `node-fetch` >=2.6.7 (CVE-2022-0235 class)
 const sensitiveHeaders = ['authorization', 'www-authenticate', 'cookie', 'cookie2']
+
+// Releases the response body stream back to the connection pool without
+// reading it. Required whenever we resolve or reject at headers (network mode
+// or error) — otherwise the socket is held until timeout/GC. Covers
+// `node-fetch` (destroy), whatwg streams (cancel), and a text() fallback.
+function drainBody (response) {
+  if (!response || !response.body) return
+  if (typeof response.body.destroy === 'function') response.body.destroy()
+  else if (typeof response.body.cancel === 'function') response.body.cancel().catch(() => {})
+  else if (typeof response.text === 'function') response.text().catch(() => {})
+}
 
 module.exports = function (url, options, _fetch, useAgent) {
   if (!options || typeof options !== 'object') options = {}
@@ -52,6 +64,17 @@ module.exports = function (url, options, _fetch, useAgent) {
   // Eager `fields` option validation — throws before any network round-trip
   // on an invalid selection (unknown token, empty array, wrong shape).
   resolveFields(opts.fields)
+
+  // The `network` group is a live-transaction probe; it has no meaning when
+  // parsing a passed-in Response (no fetch happens). Guard eagerly.
+  if (opts.parseResponseObject && hasNetworkGroup(opts.fields)) {
+    throw new Error("`fields: ['network']` is not supported in parseResponseObject mode")
+  }
+
+  // Header-only selection (`network` or a subset of its atomic fields): the
+  // body read can be skipped. Engages for live fetches only — filtering in
+  // parseResponseObject mode is handled separately.
+  const headerOnly = !opts.parseResponseObject && isHeaderOnly(opts.fields)
 
   // Proxy calls route through a third-party service doing its own upstream
   // fetch (plus optional headless rendering via params like ScraperAPI's
@@ -228,12 +251,36 @@ module.exports = function (url, options, _fetch, useAgent) {
           throwGenericError()
         }
 
-        // Validate response content type
-        contentType = response.headers.get('content-type')
-        const isHTML = contentType && contentType.includes('html')
+        // Header-only (`fields: ['network']`) mode: everything requested is
+        // available from the response headers. When the caller doesn't also
+        // want the raw body, skip the body entirely — drain the stream to
+        // release the socket, then resolve.
+        // `performance.responseTimeMs` stays undefined (body unread).
+        if (headerOnly && !opts.includeResponseBody) {
+          drainBody(response)
+          resolve(parse.headerOnly(
+            requestUrl,
+            redirects,
+            perf,
+            finalUrl,
+            response.status,
+            response.headers,
+            expandHeaderSelection(opts.fields),
+            undefined,
+            opts
+          ))
+          return
+        }
 
-        if (!isHTML) {
-          throw createHttpError({ msg: `unsupported content type: ${contentType}`, statusCode: response.status, redirects, requestUrl, url: finalUrl })
+        // Read content type (also used for charset detection below). In
+        // header-only mode we don't enforce HTML, so a `network` probe works
+        // against any content type (PDF, JSON, image).
+        contentType = response.headers.get('content-type')
+        if (!headerOnly) {
+          const isHTML = contentType && contentType.includes('html')
+          if (!isHTML) {
+            throw createHttpError({ msg: `unsupported content type: ${contentType}`, statusCode: response.status, redirects, requestUrl, url: finalUrl })
+          }
         }
 
         // Now, read the fetch response stream to completion,
@@ -262,7 +309,25 @@ module.exports = function (url, options, _fetch, useAgent) {
           const decoder = new TextDecoder(charset)
           const responseDecoded = decoder.decode(responseBuffer)
 
-          // now parse the metadata!
+          // Header-only mode reaches here only when `includeResponseBody` is
+          // set: return the transport fields + raw body, skipping cheerio and
+          // all extractors.
+          if (headerOnly) {
+            resolve(parse.headerOnly(
+              requestUrl,
+              redirects,
+              perf,
+              finalUrl,
+              currentResponse.status,
+              currentResponse.headers,
+              expandHeaderSelection(opts.fields),
+              responseDecoded,
+              opts
+            ))
+            return
+          }
+
+          // Now parse the metadata!
           resolve(parse(
             requestUrl,
             redirects,
@@ -280,14 +345,7 @@ module.exports = function (url, options, _fetch, useAgent) {
       .catch(error => {
         // Catch all errors thrown above; they must fall thru this block to
         // clean up resources and avoid memory leaks
-        if (currentResponse && currentResponse.body) {
-          // Node.js: Destroy the body stream `node-fetch` uses to force-close the connection
-          if (typeof currentResponse.body.destroy === 'function') currentResponse.body.destroy()
-          // Modern browsers and Node.js 18+ have cancel() on the ReadableStream
-          else if (typeof currentResponse.body.cancel === 'function') currentResponse.body.cancel().catch(() => {})
-          // Fallback: consume the stream to close the connection
-          else if (typeof currentResponse.text === 'function') currentResponse.text().catch(() => {})
-        }
+        drainBody(currentResponse)
         // Set status code on error if it wasn't set already
         if (currentResponse && currentResponse.status && !error.statusCode) {
           error.statusCode = currentResponse.status

--- a/main.js
+++ b/main.js
@@ -38,6 +38,8 @@ module.exports = function (url, options, _fetch, useAgent) {
       proxyUrl: undefined, // proxy/unblocking service endpoint (ex: ScraperAPI); presence of this triggers proxy mode
       proxyParams: undefined, // optional vendor query params, passed through verbatim exactly as named in their docs (ex: ScraperAPI's api_key, render, screenshot, country_code) - some vendors need none (ex: header-auth vendors, see requestHeaders)
       parseResponseObject: undefined,
+      fields: undefined, // sparse fieldset (array of atomic keys and/or group names); undefined returns full result
+      omitEmpty: false, // drop empty fields (undefined, null, '', [], {}) from result for token efficiency
       requestFilteringAgentOptions: undefined, // Node.js v18+ only, silently ignored by others
       agent: undefined, // Node.js only; silently ignored by others
       maxRedirects: 10,
@@ -49,9 +51,7 @@ module.exports = function (url, options, _fetch, useAgent) {
       cache: 'no-cache', // Browser only
       mode: 'cors', // Browser only
       descriptionLength: 750,
-      includeResponseBody: false,
-      omitEmpty: false, // drop empty fields (undefined, null, '', [], {}) from result for token efficiency
-      fields: undefined // sparse fieldset (array of atomic keys and/or group names); undefined returns full result
+      includeResponseBody: false
     },
     // user options override defaults
     options

--- a/main.js
+++ b/main.js
@@ -71,6 +71,16 @@ module.exports = function (url, options, _fetch, useAgent) {
     throw new Error("`fields: ['network']` is not supported in parseResponseObject mode")
   }
 
+  // Header-only selections (`network` or a subset of its transport fields)
+  // probe the *target* URL. In proxy mode the response is the proxy's
+  // envelope, so status/headers/redirects/timing would describe the proxy
+  // call, not the target — and the (billed) upstream fetch has already
+  // happened, so the body-skip saves nothing. Misleading with no upside;
+  // plus wastes a billed fetch. Refuse it eagerly.
+  if (opts.proxyUrl && isHeaderOnly(opts.fields)) {
+    throw new Error("header-only `fields` (ex: 'network') are not supported in proxy mode: transport data would reflect the proxy, not the target url")
+  }
+
   // Header-only selection (`network` or a subset of its atomic fields): the
   // body read can be skipped. Engages for live fetches only — filtering in
   // parseResponseObject mode is handled separately.

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const extractCharset = require('./lib/extract-charset')
 const parse = require('./lib/parse')
 const createHttpError = require('./lib/http-error')
+const resolveFields = require('./lib/resolve-fields')
 
 // Monotonic clock when available (browsers + Node 16+), else wall clock fallback.
 // Every perf value is a delta from the same source, so the two never mix.
@@ -37,7 +38,8 @@ module.exports = function (url, options, _fetch, useAgent) {
       mode: 'cors', // Browser only
       descriptionLength: 750,
       includeResponseBody: false,
-      omitEmpty: false // drop empty fields (undefined, null, '', [], {}) from result for token efficiency
+      omitEmpty: false, // drop empty fields (undefined, null, '', [], {}) from result for token efficiency
+      fields: undefined // sparse fieldset (array of atomic keys and/or group names); undefined returns full result
     },
     // user options override defaults
     options
@@ -46,6 +48,10 @@ module.exports = function (url, options, _fetch, useAgent) {
   if (opts.proxyParams && !opts.proxyUrl) {
     throw new Error('proxyParams requires a proxyUrl')
   }
+
+  // Eager `fields` option validation — throws before any network round-trip
+  // on an invalid selection (unknown token, empty array, wrong shape).
+  resolveFields(opts.fields)
 
   // Proxy calls route through a third-party service doing its own upstream
   // fetch (plus optional headless rendering via params like ScraperAPI's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "description": "Fetch a URL and scrape its metadata using Node.js or the browser. Can parse metadata from HTML strings or Response objects as well.",
   "keywords": [
     "html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "5.8.2",
+  "version": "5.9.0",
   "description": "Fetch a URL and scrape its metadata using Node.js or the browser. Can parse metadata from HTML strings or Response objects as well.",
   "keywords": [
     "html",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "standard": {
     "globals": [
       "expect",
-      "test"
+      "test",
+      "jest"
     ],
     "ignore": [
       "/example-typescript",

--- a/test/fields-gating.test.js
+++ b/test/fields-gating.test.js
@@ -19,12 +19,7 @@ function res () {
   return new Response(html, { headers: { 'Content-Type': 'text/html' } })
 }
 
-beforeEach(() => {
-  extractJsonLd.mockClear()
-  extractHeadings.mockClear()
-  extractImgTags.mockClear()
-  extractMetaTags.mockClear()
-})
+// Mock call data is cleared before every test via jest config `clearMocks`.
 
 test('gating: skips all expensive extractors for a non-matching selection', async () => {
   await urlMetadata(null, { parseResponseObject: res(), fields: ['title'] })

--- a/test/fields-gating.test.js
+++ b/test/fields-gating.test.js
@@ -1,0 +1,68 @@
+// Extractor gating is a pure performance optimization: an extractor runs only
+// when its output is selected. These tests assert control flow (which
+// extractors run), so the extractor modules are mocked. Output correctness
+// under gating is covered by fields-groups.test.js against the real modules.
+
+jest.mock('../lib/extract-json-ld', () => jest.fn(() => []))
+jest.mock('../lib/extract-headings', () => jest.fn(() => []))
+jest.mock('../lib/extract-img-tags', () => jest.fn(() => []))
+jest.mock('../lib/extract-meta-tags', () => jest.fn(() => ({})))
+
+const extractJsonLd = require('../lib/extract-json-ld')
+const extractHeadings = require('../lib/extract-headings')
+const extractImgTags = require('../lib/extract-img-tags')
+const extractMetaTags = require('../lib/extract-meta-tags')
+const urlMetadata = require('../index')
+
+const html = '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><h1>Hi</h1></body></html>'
+function res () {
+  return new Response(html, { headers: { 'Content-Type': 'text/html' } })
+}
+
+beforeEach(() => {
+  extractJsonLd.mockClear()
+  extractHeadings.mockClear()
+  extractImgTags.mockClear()
+  extractMetaTags.mockClear()
+})
+
+test('gating: skips all expensive extractors for a non-matching selection', async () => {
+  await urlMetadata(null, { parseResponseObject: res(), fields: ['title'] })
+  expect(extractJsonLd).not.toHaveBeenCalled()
+  expect(extractHeadings).not.toHaveBeenCalled()
+  expect(extractImgTags).not.toHaveBeenCalled()
+  expect(extractMetaTags).not.toHaveBeenCalled()
+})
+
+test('gating: runs only jsonld when jsonld is selected', async () => {
+  await urlMetadata(null, { parseResponseObject: res(), fields: ['jsonld'] })
+  expect(extractJsonLd).toHaveBeenCalledTimes(1)
+  expect(extractHeadings).not.toHaveBeenCalled()
+  expect(extractImgTags).not.toHaveBeenCalled()
+  expect(extractMetaTags).not.toHaveBeenCalled()
+})
+
+test('gating: og group runs the meta-tag extractor only', async () => {
+  await urlMetadata(null, { parseResponseObject: res(), fields: ['og'] })
+  expect(extractMetaTags).toHaveBeenCalledTimes(1)
+  expect(extractJsonLd).not.toHaveBeenCalled()
+})
+
+test('gating: `meta` group runs the meta-tag extractor', async () => {
+  await urlMetadata(null, { parseResponseObject: res(), fields: ['meta'] })
+  expect(extractMetaTags).toHaveBeenCalledTimes(1)
+})
+
+test('gating: an atomic meta key (description) runs the meta-tag extractor', async () => {
+  await urlMetadata(null, { parseResponseObject: res(), fields: ['description'] })
+  expect(extractMetaTags).toHaveBeenCalledTimes(1)
+  expect(extractJsonLd).not.toHaveBeenCalled()
+})
+
+test('gating: no `fields` runs every extractor (full output)', async () => {
+  await urlMetadata(null, { parseResponseObject: res() })
+  expect(extractJsonLd).toHaveBeenCalledTimes(1)
+  expect(extractHeadings).toHaveBeenCalledTimes(1)
+  expect(extractImgTags).toHaveBeenCalledTimes(1)
+  expect(extractMetaTags).toHaveBeenCalledTimes(1)
+})

--- a/test/fields-groups.test.js
+++ b/test/fields-groups.test.js
@@ -1,0 +1,160 @@
+const urlMetadata = require('../index')
+const MetadataFields = require('../lib/metadata-fields')
+const { selectFields, NON_META_KEYS } = require('../lib/resolve-fields')
+
+// -- selectFields unit test (pure) --
+
+const full = {
+  requestUrl: 'https://x.test',
+  url: 'https://x.test',
+  title: 'T',
+  description: 'D',
+  charset: 'utf-8',
+  'og:title': 'OT',
+  'og:url': '',
+  'twitter:card': 'summary',
+  'dc.creator': 'Jane', // arbitrary meta tag
+  favicons: [],
+  redirects: {},
+  responseStatusCode: 200
+}
+
+test('selectFields: atomic keys', () => {
+  const r = selectFields(full, ['title', 'description'])
+  expect(Object.keys(r).sort()).toEqual(['description', 'title'])
+})
+
+test('selectFields: og prefix keeps empty whitelisted og keys (orthogonal to omitEmpty)', () => {
+  const r = selectFields(full, ['og'])
+  expect(Object.keys(r).sort()).toEqual(['og:title', 'og:url'])
+  expect(r['og:url']).toBe('')
+})
+
+test('selectFields: twitter prefix', () => {
+  const r = selectFields(full, ['twitter'])
+  expect(Object.keys(r)).toEqual(['twitter:card'])
+})
+
+test('selectFields: meta includes arbitrary + charset, excludes structural', () => {
+  const r = selectFields(full, ['meta'])
+  expect('description' in r).toBe(true)
+  expect('charset' in r).toBe(true)
+  expect('dc.creator' in r).toBe(true)
+  expect('og:title' in r).toBe(true)
+  expect('twitter:card' in r).toBe(true)
+  // structural keys excluded
+  expect('title' in r).toBe(false)
+  expect('url' in r).toBe(false)
+  expect('favicons' in r).toBe(false)
+  expect('responseStatusCode' in r).toBe(false)
+})
+
+test('selectFields: meta:<name> selects one literal key', () => {
+  expect(Object.keys(selectFields(full, ['meta:dc.creator']))).toEqual(['dc.creator'])
+})
+
+test('selectFields: meta:<name> for an absent tag yields nothing', () => {
+  expect(Object.keys(selectFields(full, ['meta:not-present']))).toEqual([])
+})
+
+test('selectFields: mixed atomic + group union', () => {
+  expect(Object.keys(selectFields(full, ['title', 'twitter'])).sort())
+    .toEqual(['title', 'twitter:card'])
+})
+
+test('selectFields: result preserves source object order, not request order', () => {
+  expect(Object.keys(selectFields(full, ['description', 'title']))).toEqual(['title', 'description'])
+})
+
+test('NON_META_KEYS are all real seed keys (drift canary)', () => {
+  const seed = new MetadataFields({}).fields
+  NON_META_KEYS.forEach((k) => expect(k in seed).toBe(true))
+})
+
+// -- integration test via parseResponseObject (no network) --
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Test Page</title>
+  <meta name="description" content="A description">
+  <meta name="dc.creator" content="Jane Doe">
+  <meta property="og:title" content="OG Title">
+  <meta property="og:image" content="https://x.test/img.png">
+  <meta name="twitter:card" content="summary">
+  <link rel="canonical" href="https://x.test/canonical">
+</head>
+<body><h1>Hi</h1></body>
+</html>`
+
+function res () {
+  return new Response(html, { headers: { 'Content-Type': 'text/html' } })
+}
+
+test('fields og (integration): only og keys, empties kept', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['og'] })
+  expect(m['og:title']).toBe('OG Title')
+  expect(m['og:image']).toBe('https://x.test/img.png')
+  expect(m['og:url']).toBe('') // empty whitelisted og key kept
+  expect('twitter:card' in m).toBe(false)
+  expect('title' in m).toBe(false)
+})
+
+test('fields og + omitEmpty (integration): only filled og keys', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['og'], omitEmpty: true })
+  expect(m['og:title']).toBe('OG Title')
+  expect('og:url' in m).toBe(false) // empty stripped by omitEmpty
+})
+
+test('fields meta (integration): meta tags incl arbitrary + charset, no structural', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['meta'] })
+  expect(m.description).toBe('A description')
+  expect(m['dc.creator']).toBe('Jane Doe') // arbitrary
+  expect(m['og:title']).toBe('OG Title')
+  expect(m['twitter:card']).toBe('summary')
+  expect(m.charset).toBe('utf-8') // charset is meta (documents the decision)
+  expect('title' in m).toBe(false)
+  expect('canonical' in m).toBe(false)
+  expect('url' in m).toBe(false)
+  expect('favicons' in m).toBe(false)
+})
+
+test('fields meta:<name> (integration): arbitrary tag escape hatch', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['meta:dc.creator'] })
+  expect(Object.keys(m)).toEqual(['dc.creator'])
+  expect(m['dc.creator']).toBe('Jane Doe')
+})
+
+test('fields atomic (integration): only requested keys', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['title', 'description'] })
+  expect(Object.keys(m).sort()).toEqual(['description', 'title'])
+})
+
+test('fields atomic network field allowed in parseResponseObject mode', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['responseStatusCode'] })
+  expect(Object.keys(m)).toEqual(['responseStatusCode'])
+  expect(m.responseStatusCode).toBe(200)
+})
+
+// -- integration test w network for sanity check --
+
+test('fields test w network call', async () => {
+  const url = 'https://minifetch.com'
+  const m = await urlMetadata(url, {
+    fields: ['network', 'meta']
+  })
+  // fields: ['network']
+  expect(m.redirects).toBeDefined()
+  expect(m.responseHeaders).toBeDefined()
+  expect(m.responseStatusCode).toBeDefined()
+  expect(m.performance).toBeDefined()
+  // fields: ['meta']
+  expect(m.charset).toBeDefined()
+  expect(m.description).toBeDefined()
+  expect(m['og:url']).toBeDefined()
+  expect(m['twitter:title']).toBeDefined()
+  // `fields: ['meta']` returns arbitrary meta tags
+  // not listed in lib/metadata-fields.js
+  expect(m['apple-mobile-web-app-title']).toBe('Minifetch')
+})

--- a/test/fields-groups.test.js
+++ b/test/fields-groups.test.js
@@ -107,6 +107,16 @@ test('fields og + omitEmpty (integration): only filled og keys', async () => {
   expect('og:url' in m).toBe(false) // empty stripped by omitEmpty
 })
 
+test('fields twitter (integration): only twitter keys, empties kept', async () => {
+  const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['twitter'] })
+  expect(m['twitter:card']).toBe('summary')
+  expect(m['twitter:title']).toBe('') // empty whitelisted twitter key kept
+  expect('twitter:url' in m).toBe(true) // present-but-empty
+  expect('og:title' in m).toBe(false)
+  expect('description' in m).toBe(false)
+  expect('title' in m).toBe(false)
+})
+
 test('fields meta (integration): meta tags incl arbitrary + charset, no structural', async () => {
   const m = await urlMetadata(null, { parseResponseObject: res(), fields: ['meta'] })
   expect(m.description).toBe('A description')

--- a/test/fields-network.test.js
+++ b/test/fields-network.test.js
@@ -1,0 +1,119 @@
+const parse = require('../lib/parse')
+const { isHeaderOnly, expandHeaderSelection, hasNetworkGroup, NETWORK_FIELDS } = require('../lib/resolve-fields')
+const urlMetadata = require('../index')
+
+// -- resolve-fields network helpers (pure) --
+
+test('isHeaderOnly: true for `network` group and network-field subsets', () => {
+  expect(isHeaderOnly(['network'])).toBe(true)
+  expect(isHeaderOnly(['responseStatusCode'])).toBe(true)
+  expect(isHeaderOnly(['network', 'url'])).toBe(true)
+  expect(isHeaderOnly(['responseStatusCode', 'redirects'])).toBe(true)
+})
+
+test('isHeaderOnly: false when any body-dependent field is present', () => {
+  expect(isHeaderOnly(['network', 'title'])).toBe(false)
+  expect(isHeaderOnly(['title'])).toBe(false)
+  expect(isHeaderOnly(['og'])).toBe(false)
+})
+
+test('isHeaderOnly: false for null/undefined (no filtering)', () => {
+  expect(isHeaderOnly(null)).toBe(false)
+  expect(isHeaderOnly(undefined)).toBe(false)
+})
+
+test('expandHeaderSelection: `network` expands to all six transport fields', () => {
+  const set = expandHeaderSelection(['network'])
+  NETWORK_FIELDS.forEach((f) => expect(set.has(f)).toBe(true))
+  expect(set.size).toBe(NETWORK_FIELDS.length)
+})
+
+test('expandHeaderSelection: atomic fields pass through as themselves', () => {
+  const set = expandHeaderSelection(['responseStatusCode', 'redirects'])
+  expect([...set].sort()).toEqual(['redirects', 'responseStatusCode'])
+})
+
+test('hasNetworkGroup: true only when the `network` token is present', () => {
+  expect(hasNetworkGroup(['network'])).toBe(true)
+  expect(hasNetworkGroup(['responseStatusCode'])).toBe(false)
+  expect(hasNetworkGroup(null)).toBe(false)
+})
+
+// -- parse.headerOnly assembly (pure, no network) --
+
+const redirects = { count: 0, chain: [] }
+const perf = { redirectTimeMs: undefined, ttfbMs: 12, responseTimeMs: undefined }
+const headers = new Headers({ 'content-type': 'application/pdf', etag: 'abc123' })
+
+test('parse.headerOnly: returns exactly the requested network fields', () => {
+  const requested = expandHeaderSelection(['network'])
+  const result = parse.headerOnly(
+    'https://x.test', redirects, perf, 'https://x.test/final',
+    200, headers, requested, undefined, { includeResponseBody: false }
+  )
+  expect(Object.keys(result).sort()).toEqual(
+    ['performance', 'redirects', 'requestUrl', 'responseHeaders', 'responseStatusCode', 'url']
+  )
+  expect(result.url).toBe('https://x.test/final')
+  expect(result.responseStatusCode).toBe(200)
+  // whitelisted headers come through; no body-derived fields present
+  expect(result.responseHeaders['content-type']).toBe('application/pdf')
+  expect('title' in result).toBe(false)
+  expect('favicons' in result).toBe(false)
+})
+
+test('parse.headerOnly: atomic subset returns only those keys', () => {
+  const requested = expandHeaderSelection(['responseStatusCode', 'redirects'])
+  const result = parse.headerOnly(
+    'https://x.test', redirects, perf, 'https://x.test',
+    404, headers, requested, undefined, { includeResponseBody: false }
+  )
+  expect(Object.keys(result).sort()).toEqual(['redirects', 'responseStatusCode'])
+  expect(result.responseStatusCode).toBe(404)
+})
+
+test('parse.headerOnly: includeResponseBody adds responseBody', () => {
+  const requested = expandHeaderSelection(['network'])
+  const result = parse.headerOnly(
+    'https://x.test', redirects, perf, 'https://x.test',
+    200, headers, requested, '<html></html>', { includeResponseBody: true }
+  )
+  expect(result.responseBody).toBe('<html></html>')
+})
+
+test('parse.headerOnly: omitEmpty drops empty fields (shallow)', () => {
+  const requested = expandHeaderSelection(['network'])
+  const result = parse.headerOnly(
+    '', redirects, perf, '', // requestUrl & url empty
+    200, headers, requested, undefined, { omitEmpty: true }
+  )
+  // empty strings dropped
+  expect('requestUrl' in result).toBe(false)
+  expect('url' in result).toBe(false)
+  // keyed objects retained (omitEmpty is shallow), non-empty status kept
+  expect('performance' in result).toBe(true)
+  expect('redirects' in result).toBe(true)
+  expect(result.responseStatusCode).toBe(200)
+})
+
+// -- guard + end-to-end --
+
+test('fields: parseResponseObject + `network` group throws eagerly', () => {
+  const response = new Response('<html></html>', { headers: { 'Content-Type': 'text/html' } })
+  expect(() => urlMetadata(null, { parseResponseObject: response, fields: ['network'] }))
+    .toThrow('parseResponseObject mode')
+})
+
+test('network mode (live): returns only transport fields, body never parsed', async () => {
+  const metadata = await urlMetadata('https://example.com', { fields: ['network'] })
+  expect(metadata.responseStatusCode).toBe(200)
+  expect(metadata.url).toContain('example.com')
+  // body-derived fields must be absent (body was never read or parsed)
+  expect('title' in metadata).toBe(false)
+  expect('favicons' in metadata).toBe(false)
+  expect('jsonld' in metadata).toBe(false)
+  // responseTimeMs stays undefined (body unread); ttfb still measured
+  expect(metadata.performance.ttfbMs).toBeDefined()
+  expect(metadata.performance.ttfbMs).toBeGreaterThan(0)
+  expect(metadata.performance.responseTimeMs).toBe(undefined)
+})

--- a/test/fields-network.test.js
+++ b/test/fields-network.test.js
@@ -104,6 +104,16 @@ test('fields: parseResponseObject + `network` group throws eagerly', () => {
     .toThrow('parseResponseObject mode')
 })
 
+test('fields: proxyUrl + `network` group throws eagerly', () => {
+  expect(() => urlMetadata('https://x.test', { proxyUrl: 'https://proxy.test/', fields: ['network'] }))
+    .toThrow('proxy mode')
+})
+
+test('fields: proxyUrl + an atomic header-only field also throws (any header-only selection)', () => {
+  expect(() => urlMetadata('https://x.test', { proxyUrl: 'https://proxy.test/', fields: ['responseStatusCode'] }))
+    .toThrow('proxy mode')
+})
+
 test('network mode (live): returns only transport fields, body never parsed', async () => {
   const metadata = await urlMetadata('https://example.com', { fields: ['network'] })
   expect(metadata.responseStatusCode).toBe(200)

--- a/test/fields-network.test.js
+++ b/test/fields-network.test.js
@@ -117,3 +117,14 @@ test('network mode (live): returns only transport fields, body never parsed', as
   expect(metadata.performance.ttfbMs).toBeGreaterThan(0)
   expect(metadata.performance.responseTimeMs).toBe(undefined)
 })
+
+test('network mode (live): does not throw on non-HTML content (image/png)', async () => {
+  // A full-parse fetch would throw `unsupported content type` here;
+  // network mode skips the `isHTML` check and probes any content type.
+  const metadata = await urlMetadata('https://minifetch.com/favicon-96x96.png', { fields: ['network'] })
+  expect(metadata.responseStatusCode).toBe(200)
+  expect(metadata.responseHeaders['content-type']).toContain('image/png')
+  // body never parsed - just to be sure:
+  expect('title' in metadata).toBe(false)
+  expect('favicons' in metadata).toBe(false)
+})

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -1,0 +1,71 @@
+const resolveFields = require('../lib/resolve-fields')
+const urlMetadata = require('../index')
+
+// Step 1: `fields` default + eager validation only. Group expansion and
+// extraction gating land in later steps. These tests assert validation
+// behavior, not return shape (which becomes an expanded Set later), so valid
+// inputs are checked with `not.toThrow()` rather than deep equality.
+// Note: .toThrow('<msg>') checks that <msg> is substring of the error msg.
+
+test('fields: undefined returns null (full result, no filtering)', () => {
+  expect(resolveFields(undefined)).toBe(null)
+})
+
+test('fields: valid atomic keys pass validation', () => {
+  expect(() => resolveFields(['title', 'description'])).not.toThrow()
+})
+
+test('fields: valid group names pass validation', () => {
+  expect(() => resolveFields(['network', 'og', 'twitter', 'meta'])).not.toThrow()
+})
+
+test('fields: mix of atomic keys and group names passes', () => {
+  expect(() => resolveFields(['title', 'og', 'favicons'])).not.toThrow()
+})
+
+test('fields: empty array throws', () => {
+  expect(() => resolveFields([])).toThrow('empty array')
+})
+
+test('fields: unknown token throws (names the token)', () => {
+  expect(() => resolveFields(['titel'])).toThrow("unknown `fields` token: 'titel'")
+})
+
+test('fields: non-array throws', () => {
+  expect(() => resolveFields('title')).toThrow('must be an array')
+})
+
+test('fields: non-string token throws', () => {
+  expect(() => resolveFields(['title', 42])).toThrow('must be strings')
+})
+
+test('fields: bare `og`/`twitter` are groups, not atomic keys — still valid', () => {
+  // sanity: these resolve as group names even though bare `og` is not a key
+  expect(() => resolveFields(['og'])).not.toThrow()
+})
+
+test('fields: `meta:<name>` escape hatch passes for a page-specific tag', () => {
+  expect(() => resolveFields(['meta:dc.creator'])).not.toThrow()
+})
+
+test('fields: `meta:<name>` keeps colons in the tag name (no split)', () => {
+  expect(() => resolveFields(['meta:al:ios:url'])).not.toThrow()
+})
+
+test('fields: `meta:<name>` allows a redundant known suffix (meta:og:title)', () => {
+  expect(() => resolveFields(['meta:og:title'])).not.toThrow()
+})
+
+test('fields: bare `meta:` with no tag name throws', () => {
+  expect(() => resolveFields(['meta:'])).toThrow('missing a tag name')
+})
+
+test('fields: unknown bare token error teaches the `meta:` hatch', () => {
+  expect(() => resolveFields(['dc.creator'])).toThrow("prefix with 'meta:'")
+})
+
+test('fields: validates eagerly through urlMetadata, before any fetch', () => {
+  // throw is synchronous (like the proxyParams guard), so no network is hit
+  expect(() => urlMetadata('https://example.com', { fields: [] })).toThrow('empty array')
+  expect(() => urlMetadata('https://example.com', { fields: ['nope'] })).toThrow('unknown')
+})

--- a/test/omit-empty.test.js
+++ b/test/omit-empty.test.js
@@ -1,0 +1,81 @@
+const urlMetadata = require('./../index')
+
+// Minimal page: title/lang/charset/author populated; most other fields absent
+// (seed to empty string) so we can assert `omitEmpty` drops them. Uses
+// `parseResponseObject` so there's no network — same pattern as options.test.js.
+const html = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Metadata page</title>
+    <meta name="author" content="foobar">
+  </head>
+  <body>
+    <h1>Metadata page</h1>
+  </body>
+</html>
+`
+
+function makeResponse () {
+  return new Response(html, { headers: { 'Content-Type': 'text/html' } })
+}
+
+test('default (no omitEmpty): absent fields present as empty', async () => {
+  const metadata = await urlMetadata(null, { parseResponseObject: makeResponse() })
+  expect(metadata.redirects.chain.length).toBe(0)
+  expect(metadata.performance.redirectTimeMs).toBeUndefined()
+  expect(metadata.description).toBe('')
+  expect(metadata.favicons.length).toBe(0) // empty []
+  expect(metadata['og:title']).toBe('')
+  expect(metadata.keywords).toBe('')
+  expect(metadata.jsonld.length).toBe(0) // empty []
+})
+
+test('omitEmpty option: drops undefined, null, empty string, [], and {}', async () => {
+  const metadata = await urlMetadata(null, {
+    parseResponseObject: makeResponse(),
+    omitEmpty: true
+  })
+  expect('description' in metadata).toBe(false)
+  expect('favicons' in metadata).toBe(false)
+  expect('og:title' in metadata).toBe(false)
+  expect('keywords' in metadata).toBe(false)
+  expect('jsonld' in metadata).toBe(false)
+  expect('responseBody' in metadata).toBe(false) // '' when includeResponseBody false, the default
+  expect('url' in metadata).toBe(false) // '' in parseResponseObject mode (no fetch)
+})
+
+test('omitEmpty: retains populated fields', async () => {
+  const metadata = await urlMetadata(null, {
+    parseResponseObject: makeResponse(),
+    omitEmpty: true
+  })
+  expect(metadata.title).toBe('Metadata page')
+  expect(metadata.lang).toBe('en')
+  expect(metadata.charset).toBe('utf-8')
+  expect(metadata.author).toBe('foobar')
+  expect(metadata.responseStatusCode).toBe(200)
+  expect(metadata.headings.length).toBe(1)
+})
+
+test('omitEmpty is shallow: strips empty, keeps populated & keyed', async () => {
+  const metadata = await urlMetadata(null, {
+    parseResponseObject: makeResponse(),
+    omitEmpty: true
+  })
+  // empty arrays stripped
+  expect('favicons' in metadata).toBe(false) // []
+  expect('jsonld' in metadata).toBe(false) // []
+  // null stripped (requestUrl is null in parseResponseObject mode)
+  expect('requestUrl' in metadata).toBe(false)
+  // populated arrays survive (page has one <h1>)
+  expect(metadata.headings.length).toBe(1)
+  // nested objects with own keys are retained whole & NOT recursed into,
+  // so performance keeps its (undefined-valued) inner keys
+  expect('redirects' in metadata).toBe(true)
+  expect(metadata.redirects.chain.length).toBe(0)
+  expect('performance' in metadata).toBe(true)
+  expect(metadata.performance).toHaveProperty('responseTimeMs')
+  expect(metadata.performance.redirectTimeMs).toBeUndefined()
+})


### PR DESCRIPTION
# Feature request: 
- [X] Implements user-selected `fields` option, as outlined in #62. 
- [X] Also implements user-selected `omitEmpty` option.
___

### Contributors checklist:
- [X] index.d.ts: ensure parameters, options & Result are still correct
- [X] `npm run test`
- [X] ensure ts example works in /example-typescript: `npm run start`
- [X] ensure vite.js example works in /example-vite: `npm run dev`

### Maintainers checklist:
- [X] `npm run test` on the new PR branch
- [X] `squash and merge` PR to master
- [X] switch to master, `git pull origin master` then `npm run test`
- [X] optional: test examples against packed local .tgz file
  - [X] `npm pack`
  - [X] `cd /example-typescript` then `npm install ../url-metadata-<version>.tgz`
  - [X] build & start, ensure no errors
  - [X] do same for other `/example-*` dirs
- [X] update README (if applicable)
- [X] update CHANGELOG (if applicable)
- [ ] update ROADMAP (if applicable)
- [X] package.json: bump semver version, push commit to master
- [X] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [X] `npm publish ./`
