### PR TITLE
Surface redirect location header along w other redirect data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+5.10.0
+- expose result-shaping helpers on the main entry: `resolveFields`, `selectFields`, `isEmpty` (filter an already-parsed result without re-fetching; used internally by the parser too)
+
 5.9.0
 - new option: `omitEmpty: true` purges empty fields from result
 - new option: `fields: []` accepts named groups or atomic field names

--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,5 @@
 const main = require('./main')
+const resolveFields = require('./lib/resolve-fields')
 
 module.exports = function (url, options) {
   // In browser, use native fetch
@@ -13,3 +14,10 @@ module.exports = function (url, options) {
 
   return main(url, options, _fetch, useAgent)
 }
+
+// Mirror of index.js: expose the result-shaping helpers on the browser
+// entry too, so bundled consumers get parity. The resolve-fields chain is
+// pure/isomorphic (no node-only deps), so this is browser-safe.
+module.exports.resolveFields = resolveFields
+module.exports.selectFields = resolveFields.selectFields
+module.exports.isEmpty = resolveFields.isEmpty

--- a/example-typescript/index.ts
+++ b/example-typescript/index.ts
@@ -104,3 +104,28 @@ async function sparseReturnTypeCanary (url: string) {
 
   return [okPicked, strictPicked, okPruned, strictPruned, okFull, okPlain];
 }
+
+// --- COMPILE-ONLY canary: result-shaping statics on the main entry. Never called. ---
+// Locks the namespace-merged signatures for resolveFields/selectFields/isEmpty
+// exposed in 5.10.0. If this stops compiling, index.d.ts has drifted from the
+// statics attached at runtime in index.js/browser.js. DO NOT CALL.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function shapingStaticsCanary (url: string) {
+  const full = await urlMetadata(url); // Result
+
+  // resolveFields: string[] | undefined -> string[] | null
+  const tokens: string[] | null = urlMetadata.resolveFields(['title', 'og']);
+  const none: string[] | null = urlMetadata.resolveFields(undefined);
+
+  // selectFields: (object, string[]) -> Partial<KnownFields>
+  const picked = urlMetadata.selectFields(full, ['title', 'og']);
+  const okPicked: Partial<urlMetadata.KnownFields> = picked; // assignable
+  const title: string | undefined = picked.title; // known key is optional & typed
+  // @ts-expect-error Partial (optional fields) is NOT assignable to the all-present Strict shape
+  const strictPicked: urlMetadata.KnownFieldsStrict = picked;
+
+  // isEmpty: unknown -> boolean
+  const empty: boolean = urlMetadata.isEmpty(picked.favicons);
+
+  return [tokens, none, okPicked, title, strictPicked, empty];
+}

--- a/example-typescript/package.json
+++ b/example-typescript/package.json
@@ -8,7 +8,7 @@
     "start": "http-server dist"
   },
   "dependencies": {
-    "url-metadata": "file:../url-metadata-5.9.0.tgz"
+    "url-metadata": "file:../url-metadata-5.10.0.tgz"
   },
   "devDependencies": {
     "assert": "^2.1.0",

--- a/index.d.ts
+++ b/index.d.ts
@@ -231,6 +231,7 @@ declare namespace urlMetadata {
     order: number; // 1-based position in the chain (first hop is order: 1)
     url: string; // the url requested at this hop
     statusCode: number; // the 3xx status returned by this hop
+    location: string; // resolved absolute url this hop redirects to (its Location header)
   }
 
   /**
@@ -245,6 +246,7 @@ declare namespace urlMetadata {
       chain: RedirectHop[];
     };
     url?: string; // final destination url in request chain
+    notFollowedRedirect?: boolean; // true when this error is a redirect left unfollowed (maxRedirects reached), not a transport error; next-hop url is `url` / last redirects.chain[].location
     statusCode?: number;
     paymentRequired?: boolean;
     x402?: Record<string, any>; // x402 payment requirements - https://www.x402.org/

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,25 @@ declare function urlMetadata(
 ): Promise<urlMetadata.Result>
 
 declare namespace urlMetadata {
+
+  // Helper Functions ---
+  // Result-shaping helpers exposed on the main entry (index.js & browser.js).
+  // So consumers can filter an already-parsed result without re-fetching.
+
+  // Validate a `fields` selection eagerly. Returns the tokens, or null when
+  // `fields` is undefined (signal: no filtering). Throws on a non-array, empty
+  // array, non-string token, `meta:` with no name, or unknown bare token.
+  function resolveFields(fields: string[] | undefined): string[] | null;
+
+  // Project a full result down to a validated `fields` selection. Only keys
+  // present in `metadata` are returned; groups expand against its own keys.
+  function selectFields(metadata: Record<string, any>, fields: string[]): Partial<KnownFields>;
+
+  // The `omitEmpty` predicate: true for undefined, null, '', [], {} (shallow).
+  function isEmpty(value: unknown): boolean;
+
+  // end Helper Functions ---
+
   interface Options {
     requestHeaders?: Record<string, string>;
     proxyUrl?: string; // proxy/unblocking service endpoint (ex: https://api.scraperapi.com/); presence of this triggers proxy mode

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 const nodeFetch = require('node-fetch')
 const requestFilteringAgent = require('request-filtering-agent')
 const main = require('./main')
+const resolveFields = require('./lib/resolve-fields')
 
 module.exports = function (url, options) {
   // Handle Next.js bundler converting CommonJS `node-fetch` to ES module structure
@@ -18,3 +19,13 @@ module.exports = function (url, options) {
 
   return main(url, options, _fetch, useAgent)
 }
+
+// Result-shaping helpers, exposed on the public surface so consumers can
+// filter an already-parsed result without re-fetching (single source of
+// truth; used internally by the parser too):
+//   resolveFields(fields) -> validate a `fields` selection (throws on bad input)
+//   selectFields(metadata, fields) -> project a full result to the selection
+//   isEmpty(value) -> the `omitEmpty` predicate
+module.exports.resolveFields = resolveFields
+module.exports.selectFields = resolveFields.selectFields
+module.exports.isEmpty = resolveFields.isEmpty

--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -5,7 +5,8 @@ module.exports = function ({
   url,
   statusCode,
   paymentRequired,
-  x402
+  x402,
+  notFollowedRedirect
 }) {
   const error = new Error(msg)
   if (requestUrl) error.requestUrl = requestUrl
@@ -14,6 +15,7 @@ module.exports = function ({
   if (statusCode) error.statusCode = statusCode
   if (paymentRequired) error.paymentRequired = paymentRequired
   if (x402) error.x402 = x402
+  if (notFollowedRedirect) error.notFollowedRedirect = notFollowedRedirect
 
   return error
 }

--- a/lib/resolve-fields.js
+++ b/lib/resolve-fields.js
@@ -1,4 +1,5 @@
 const MetadataFields = require('./metadata-fields')
+const { isEmpty } = require('./utils')
 
 // Valid atomic field keys, derived from the seed object (single source of
 // truth in metadata-fields.js) so this list can never drift from what the
@@ -210,3 +211,6 @@ module.exports.hasNetworkGroup = hasNetworkGroup
 module.exports.selectFields = selectFields
 module.exports.selectionIncludes = selectionIncludes
 module.exports.needsMetaTags = needsMetaTags
+// Re-exported from ./utils so the public result-shaping trio
+// (resolveFields, selectFields, isEmpty) lives on one module.
+module.exports.isEmpty = isEmpty

--- a/main.js
+++ b/main.js
@@ -28,8 +28,8 @@ function drainBody (response) {
 module.exports = function (url, options, _fetch, useAgent) {
   if (!options || typeof options !== 'object') options = {}
 
+  // Defaults
   const opts = Object.assign(
-    // defaults
     {
       requestHeaders: {
         'User-Agent': 'url-metadata (+https://www.npmjs.com/package/url-metadata)',
@@ -123,7 +123,9 @@ module.exports = function (url, options, _fetch, useAgent) {
 
   async function fetchData (_url, redirectCount = 0, requestHeaders = opts.requestHeaders) {
     if (redirectCount > opts.maxRedirects) {
-      throw createHttpError({ msg: 'too many redirects', redirects, requestUrl, url: _url })
+      // `notFollowedRedirect` flags this as a redirect we declined to follow
+      // (maxRedirects reached), not a transport error
+      throw createHttpError({ msg: 'too many redirects', redirects, requestUrl, url: _url, notFollowedRedirect: true })
     }
     if (!_url && !opts.parseResponseObject) {
       throw new Error('url parameter is missing')
@@ -171,16 +173,21 @@ module.exports = function (url, options, _fetch, useAgent) {
 
       // If response is 3xx redirect
       if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
-        // Collect redirects in object that is passed back to user
+        // Resolve the Location header against this hop's url (relative allowed).
+        const newUrl = new URL(response.headers.get('location'), _url).href
+        // Collect redirects in object that is passed back to user. `location`
+        // exposes each hop's resolved destination, so a caller can inspect a
+        // redirect without following it (ex: a maxRedirects: 0 hop-walk that
+        // robots-checks each destination before requesting it).
         redirects.count = redirectCount + 1
         redirects.chain.push({
           order: redirects.count,
           url: _url,
-          statusCode: response.status
+          statusCode: response.status,
+          location: newUrl
         })
         // Then, follow the redirect. Strip sensitive headers when the hop
         // crosses hosts; once stripped they stay stripped for later hops.
-        const newUrl = new URL(response.headers.get('location'), _url).href
         let nextHeaders = requestHeaders
         // Compare exact host - its what browsers, curl, unidici do
         if (new URL(newUrl).host !== new URL(_url).host) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-metadata",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Fetch a URL and scrape its metadata using Node.js or the browser. Can parse metadata from HTML strings or Response objects as well.",
   "keywords": [
     "html",

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1,0 +1,67 @@
+const urlMetadata = require('../index')
+const browserEntry = require('../browser')
+const resolveFieldsModule = require('../lib/resolve-fields')
+
+// The result-shaping trio (resolveFields, selectFields, isEmpty) is exposed on
+// the public entry (5.10.0) so consumers can filter an already-parsed result
+// without re-fetching. These tests assert the surface exists, is the SAME
+// reference as the internal single source of truth (guards against a divergent
+// copy drifting), is mirrored on the browser entry, and behaves.
+
+test('index exposes the result-shaping trio as functions', () => {
+  expect(typeof urlMetadata.resolveFields).toBe('function')
+  expect(typeof urlMetadata.selectFields).toBe('function')
+  expect(typeof urlMetadata.isEmpty).toBe('function')
+})
+
+test('exposed helpers are the internal ones (single source of truth, no copy)', () => {
+  expect(urlMetadata.resolveFields).toBe(resolveFieldsModule)
+  expect(urlMetadata.selectFields).toBe(resolveFieldsModule.selectFields)
+  expect(urlMetadata.isEmpty).toBe(resolveFieldsModule.isEmpty)
+})
+
+test('browser entry mirrors the same trio (same refs, no drift between entries)', () => {
+  expect(browserEntry.resolveFields).toBe(urlMetadata.resolveFields)
+  expect(browserEntry.selectFields).toBe(urlMetadata.selectFields)
+  expect(browserEntry.isEmpty).toBe(urlMetadata.isEmpty)
+})
+
+test('selectFields projects a full object to the selection (groups expand, empties kept)', () => {
+  const full = {
+    title: 'x',
+    description: 'd',
+    'og:url': 'y',
+    'og:title': '', // empty, but selection is orthogonal to omitEmpty -> kept
+    'twitter:card': 'summary',
+    redirects: {}
+  }
+  // og group -> every key starting 'og:'; description/twitter/redirects dropped
+  expect(urlMetadata.selectFields(full, ['title', 'og'])).toEqual({
+    title: 'x',
+    'og:url': 'y',
+    'og:title': ''
+  })
+})
+
+test('selectFields: meta:<name> selects a page-specific key literally (colons kept)', () => {
+  const full = { title: 'x', 'al:ios:url': 'app://z' }
+  expect(urlMetadata.selectFields(full, ['meta:al:ios:url'])).toEqual({ 'al:ios:url': 'app://z' })
+})
+
+test('selectFields: only keys present in the object are returned', () => {
+  // meta:<name> for a tag the page lacks is simply absent (not undefined-valued)
+  const full = { title: 'x' }
+  expect(urlMetadata.selectFields(full, ['meta:dc.creator'])).toEqual({})
+})
+
+test('isEmpty is the omitEmpty predicate (undefined, null, "", [], {})', () => {
+  const empties = [undefined, null, '', [], {}]
+  const nonEmpties = ['x', 0, false, ['a'], { a: 1 }]
+  empties.forEach(v => expect(urlMetadata.isEmpty(v)).toBe(true))
+  nonEmpties.forEach(v => expect(urlMetadata.isEmpty(v)).toBe(false))
+})
+
+test('resolveFields on the public entry validates (undefined -> null, unknown -> throw)', () => {
+  expect(urlMetadata.resolveFields(undefined)).toBe(null)
+  expect(() => urlMetadata.resolveFields(['nope'])).toThrow('unknown')
+})


### PR DESCRIPTION
On both success and error paths.
___

### Contributors checklist:
- [ ] index.d.ts: ensure parameters, options & Result are still correct
- [ ] `npm run test`
- [ ] ensure ts example works in /example-typescript: `npm run start`
- [ ] ensure vite.js example works in /example-vite: `npm run dev`

### Maintainers checklist:
- [ ] `npm run test` on the new PR branch
- [ ] `squash and merge` PR to master
- [ ] switch to master, `git pull origin master` then `npm run test`
- [ ] optional: test examples against packed local .tgz file
  - [ ] `npm pack`
  - [ ] `cd /example-typescript` then `npm install ../url-metadata-<version>.tgz`
  - [ ] build & start, ensure no errors
  - [ ] do same for other `/example-*` dirs
- [ ] update README (if applicable)
- [ ] update CHANGELOG (if applicable)
- [ ] update ROADMAP (if applicable)
- [ ] package.json: bump semver version, push commit to master
- [ ] git tag new version of master
        `$ git pull origin master`
        `$ npm run test`
        `$ git tag 1.0`
        `$ git push origin 1.0`
- [ ] `npm publish ./`
